### PR TITLE
debugger attach/launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,23 +5,19 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Attach using delve",
+            "name": "Attach to Process",
             "type": "go",
             "request": "attach",
-            "preLaunchTask": "delve",
-            "mode": "remote",
-            "remotePath": "${workspaceFolder}",
-            "port" : 23456,
-            "host" : "127.0.0.1",
-            "cwd" : "${workspaceFolder}",
+            "mode": "local",
+            "processId": 0
         },
         {
             "name" : "Run query and exit",
             "type" : "go",
             "request": "launch",
             "mode" : "auto",
-            "program": "${fileDirname}",
+            "program": "${workspaceFolder}/cmd/sqlcmd",
             "args" : ["-Q", "\"select 100 as Count\""],
-        }
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,34 +3,6 @@
     // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
-        {
-            "label": "delve",
-            "type": "shell",
-            "command": "dlv debug --headless --listen=:23456 --api-version=2 \"${workspaceFolder}\"",
-            "isBackground": true,
-            "presentation": {
-                "focus": true,
-                "panel": "dedicated",
-                "clear": false
-            },
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "problemMatcher": {
-                "pattern": {
-                    "regexp": ""
-                },
-                "background": {
-                    "activeOnStart": true,
-                    "beginsPattern": {
-                        "regexp": ".*"
-                    },
-                    "endsPattern": {
-                        "regexp": ".*server listening.*"
-                    }
-                }
-            }
-        }
+ 
     ]
 }


### PR DESCRIPTION
Updated launch.json to have an attach and a launch option.  attach is setup to attach to debugger on local instance.  PID of 0 means choose process from VS Code cmd palette dropdown.  Cleaned up the delve entry in tasks.json as it isn't needed anymore.  