### PR TITLE
Switch out AAD auth implementation to leverage go-mssqldb

### DIFF
--- a/.pipelines/TestSql2017.yml
+++ b/.pipelines/TestSql2017.yml
@@ -17,13 +17,13 @@ steps:
 
   - template: include-runtests-linux.yml
     parameters:
-      RunName: 'SQL 2017'
+      RunName: 'SQL2017'
       SQLCMDUSER: sa
       SQLPASSWORD: $(PASSWORD)
       
   - template: include-runtests-linux.yml
     parameters:
-      RunName: 'SQL DB'
+      RunName: 'SQLDB'
       # AZURESERVER must be defined as a variable in the pipeline
       SQLCMDSERVER: $(AZURESERVER)
       AZURECLIENTSECRET: $(AZURECLIENTSECRET)
@@ -31,7 +31,7 @@ steps:
   - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
     displayName: Merge coverage data
     inputs:
-      reports: '"SQL 2017.coverage.xml";"SQL DB.coverage.xml"' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
+      reports: '**/*.coverage.xml"' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
       targetdir: 'coverage' # REQUIRED # The directory where the generated report should be saved.
       reporttypes: 'HtmlInline_AzurePipelines;Cobertura' # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
       sourcedirs: '$(Build.SourcesDirectory)' # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.

--- a/.pipelines/include-runtests-linux.yml
+++ b/.pipelines/include-runtests-linux.yml
@@ -38,7 +38,7 @@ steps:
   - task: PublishTestResults@2
     displayName: "Publish junit-style results"
     inputs:
-      testResultsFiles: '${{ parameters.RunName }}.coverage.xml'
+      testResultsFiles: '${{ parameters.RunName }}.testresults.xml'
       testResultsFormat: JUnit
       searchFolder: '$(Build.SourcesDirectory)'
       testRunTitle: '${{ parameters.RunName }} - $(Build.SourceBranchName)'

--- a/.pipelines/include-runtests-linux.yml
+++ b/.pipelines/include-runtests-linux.yml
@@ -20,7 +20,7 @@ steps:
   - script: |
       ~/go/bin/gotestsum --junitfile "${{ parameters.RunName }}.testresults.xml" -- ./... -coverprofile="${{ parameters.RunName }}.coverage.txt" -covermode count
       ~/go/bin/gocov convert "${{ parameters.RunName }}.coverage.txt" > "${{ parameters.RunName }}.coverage.json"
-      ~/go/bin/gocov-xml < "${{ parameters.RunName }}.coverage.json" > "${{ parameters.RunName }}.coverage.xml"
+      ~/go/bin/gocov-xml < "${{ parameters.RunName }}.coverage.json" > ${{ parameters.RunName }}.coverage.xml
       mkdir -p coverage
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'run tests'
@@ -38,7 +38,7 @@ steps:
   - task: PublishTestResults@2
     displayName: "Publish junit-style results"
     inputs:
-      testResultsFiles: '"${{ parameters.RunName }}.coverage.xml"'
+      testResultsFiles: '${{ parameters.RunName }}.coverage.xml'
       testResultsFormat: JUnit
       searchFolder: '$(Build.SourcesDirectory)'
       testRunTitle: '${{ parameters.RunName }} - $(Build.SourceBranchName)'

--- a/.pipelines/include-runtests-linux.yml
+++ b/.pipelines/include-runtests-linux.yml
@@ -42,5 +42,5 @@ steps:
       testResultsFormat: JUnit
       searchFolder: '$(Build.SourcesDirectory)'
       testRunTitle: '${{ parameters.RunName }} - $(Build.SourceBranchName)'
+      failTaskOnFailedTests: true
     condition: always()
-    continueOnError: true

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ We will be implementing command line switches and behaviors over time. Several s
 
 - `-P` switch will be removed. Passwords for SQL authentication can only be provided through these mechanisms:
 
-    -The `SQLCMDPASSWORD` environment variable
-    -The `:CONNECT` command
-    -When prompted, the user can type the password to complete a connection
+    - The `SQLCMDPASSWORD` environment variable
+    - The `:CONNECT` command
+    - When prompted, the user can type the password to complete a connection (pending [#50](https://github.com/microsoft/go-sqlcmd/issues/50))
 
 - `-R` switch will be removed. The go runtime does not provide access to user locale information, and it's not readily available through syscall on all supported platforms.
 - `-I` switch will be removed. To disable quoted identifier behavior, add `SET QUOTED IDENTIFIER OFF` in your scripts.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We will be implementing command line switches and behaviors over time. Several s
 
 ### Azure Active Directory Authentication
 
-This version of sqlcmd supports a broader range of AAD authentication models, based on the [azidentity package](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity).
+This version of sqlcmd supports a broader range of AAD authentication models, based on the [azidentity package](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity). The implementation relies on an AAD Connector in the [driver](https://github.com/denisenkom/go-mssqldb).
 
 #### Command line
 
@@ -61,7 +61,6 @@ Set `AZURE_TENANT_ID` environment variable to the tenant id of the server if not
 `ActiveDirectoryInteractive`
 
 This method will launch a web browser to authenticate the user.
-Set `AZURE_TENANT_ID` environment variable to the tenant id of the server if not using the default.
 
 `ActiveDirectoryManagedIdentity`
 
@@ -69,14 +68,12 @@ Use this method when running sqlcmd on an Azure VM that has either a system-assi
 
 `ActiveDirectoryServicePrincipal`
 
-This method authenticates the provided user name as a service principal id and the password as the client secret for the service principal. Set `AZURE_TENANT_ID` environment variable to the tenant id of the service principal.
+This method authenticates the provided user name as a service principal id and the password as the client secret for the service principal. Provide a user name in the form `<service principal id>@<tenant id>`. Set `SQLCMDPASSWORD` variable to the client secret. If using a certificate instead of a client secret, set `AZURE_CLIENT_CERTIFICATE_PATH` environment variable to the path of the certificate file.
 
 ### Environment variables for AAD auth
 
 Some settings for AAD auth do not have command line inputs, and some environment variables are consumed directly by the `azidentity` package used by `sqlcmd`.
 These environment variables can be set to configure some aspects of AAD auth and to bypass default behaviors. In addition to the variables listed above, the following are sqlcmd-specific and apply to multiple methods.
-
-`SQLCMDAZURERESOURCE` - defines the URL of the Azure SQL database resource in the Azure cloud where the database resides. By default, `sqlcmd` attempts to match the DNS suffix of the server name with one of the well known Azure cloud DNS suffixes. If no match is found it uses `https://database.windows.net`.
 
 `SQLCMDCLIENTID` - set this to the identifier of an application registered in your AAD which is authorized to authenticate to Azure SQL Database. Applies to `ActiveDirectoryInteractive` and `ActiveDirectoryPassword` methods.
 

--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kong"
+	"github.com/denisenkom/go-mssqldb/azuread"
 	"github.com/gohxs/readline"
 	"github.com/microsoft/go-sqlcmd/pkg/sqlcmd"
 )
@@ -75,11 +76,11 @@ func (a SQLCmdArguments) authenticationMethod(hasPassword bool) string {
 	if a.UseAad {
 		switch {
 		case a.UserName == "":
-			return sqlcmd.ActiveDirectoryIntegrated
+			return azuread.ActiveDirectoryIntegrated
 		case hasPassword:
-			return sqlcmd.ActiveDirectoryPassword
+			return azuread.ActiveDirectoryPassword
 		default:
-			return sqlcmd.ActiveDirectoryInteractive
+			return azuread.ActiveDirectoryInteractive
 		}
 	}
 	if a.AuthenticationMethod == "" {
@@ -113,9 +114,9 @@ func setVars(vars *sqlcmd.Variables, args *SQLCmdArguments) {
 				return "true"
 			}
 			switch a.AuthenticationMethod {
-			case sqlcmd.ActiveDirectoryIntegrated:
-			case sqlcmd.ActiveDirectoryInteractive:
-			case sqlcmd.ActiveDirectoryPassword:
+			case azuread.ActiveDirectoryIntegrated:
+			case azuread.ActiveDirectoryInteractive:
+			case azuread.ActiveDirectoryPassword:
 				return "true"
 			}
 			return ""

--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -174,7 +174,7 @@ func run(vars *sqlcmd.Variables) (int, error) {
 		return 1, err
 	}
 
-	iactive := args.InputFile == nil
+	iactive := args.InputFile == nil && args.Query == ""
 	var line *readline.Instance
 	if iactive {
 		line, err = readline.New(">")
@@ -215,7 +215,7 @@ func run(vars *sqlcmd.Variables) (int, error) {
 	if err != nil {
 		return 1, err
 	}
-	if iactive {
+	if iactive || s.Query != "" {
 		err = s.Run(once, false)
 	} else {
 		for f := range args.InputFile {

--- a/cmd/sqlcmd/main_test.go
+++ b/cmd/sqlcmd/main_test.go
@@ -157,7 +157,7 @@ func TestQueryAndExit(t *testing.T) {
 func TestAzureAuth(t *testing.T) {
 
 	if !canTestAzureAuth() {
-		t.Skip("AZURE auth environment variables are not set or server name is not an Azure DB name")
+		t.Skip("Server name is not an Azure DB name")
 	}
 	o, err := os.CreateTemp("", "sqlcmdmain")
 	assert.NoError(t, err, "os.CreateTemp")
@@ -180,10 +180,9 @@ func TestAzureAuth(t *testing.T) {
 	}
 }
 
+// Assuming public Azure, use AAD when SQLCMDUSER environment variable is not set
 func canTestAzureAuth() bool {
-	tenant := os.Getenv("AZURE_TENANT_ID")
-	clientId := os.Getenv("AZURE_CLIENT_ID")
-	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-	server := os.Getenv("SQLCMDSERVER")
-	return tenant != "" && clientId != "" && clientSecret != "" && strings.Contains(server, ".database.")
+	server := os.Getenv(sqlcmd.SQLCMDSERVER)
+	userName := os.Getenv(sqlcmd.SQLCMDUSER)
+	return strings.Contains(server, ".database.windows.net") && userName == ""
 }

--- a/pkg/sqlcmd/azure_auth.go
+++ b/pkg/sqlcmd/azure_auth.go
@@ -4,56 +4,18 @@
 package sqlcmd
 
 import (
-	"context"
 	"database/sql/driver"
+	"net/url"
 	"os"
-	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	mssql "github.com/denisenkom/go-mssqldb"
+	"github.com/denisenkom/go-mssqldb/azuread"
 )
 
 const (
-	ActiveDirectoryDefault          = "ActiveDirectoryDefault"
-	ActiveDirectoryIntegrated       = "ActiveDirectoryIntegrated"
-	ActiveDirectoryPassword         = "ActiveDirectoryPassword"
-	ActiveDirectoryInteractive      = "ActiveDirectoryInteractive"
-	ActiveDirectoryManagedIdentity  = "ActiveDirectoryManagedIdentity"
-	ActiveDirectoryServicePrincipal = "ActiveDirectoryServicePrincipal"
-	SqlPassword                     = "SqlPassword"
-	NotSpecified                    = "NotSpecified"
-	sqlClientId                     = "a94f9c62-97fe-4d19-b06d-472bed8d2bcf"
+	NotSpecified = "NotSpecified"
+	SqlPassword  = "SqlPassword"
+	sqlClientId  = "a94f9c62-97fe-4d19-b06d-472bed8d2bcf"
 )
-
-func azureTenantId() string {
-	t := os.Getenv("AZURE_TENANT_ID")
-	if t == "" {
-		t = "common"
-	}
-	return t
-}
-
-var resourceMap = map[string]string{
-	".database.chinacloudapi.cn":  "https://database.chinacloudapi.cn/",
-	".database.cloudapi.de":       "https://database.cloudapi.de/",
-	".database.usgovcloudapi.net": "https://database.usgovcloudapi.net/",
-	".database.windows.net":       "https://database.windows.net/",
-}
-
-func (s *Sqlcmd) getResourceUrl() string {
-	resource := os.Getenv("SQLCMDAZURERESOURCE")
-	if resource == "" {
-		server, _, _, _ := s.vars.SQLCmdServer()
-		for k := range resourceMap {
-			if strings.HasSuffix(strings.ToLower(server), k) {
-				return resourceMap[k]
-			}
-		}
-	}
-	return "https://database.windows.net"
-}
 
 func getSqlClientId() string {
 	if clientId := os.Getenv("SQLCMDCLIENTID"); clientId != "" {
@@ -63,38 +25,31 @@ func getSqlClientId() string {
 }
 
 func (s *Sqlcmd) GetTokenBasedConnection(connstr string, user string, password string) (driver.Connector, error) {
-	var cred azcore.TokenCredential
-	var err error
-	scope := ".default"
-	t := azureTenantId()
-	switch s.Connect.AuthenticationMethod {
-	case ActiveDirectoryDefault:
-		cred, err = azidentity.NewDefaultAzureCredential(nil)
-	case ActiveDirectoryInteractive:
-		cred, err = azidentity.NewInteractiveBrowserCredential(&azidentity.InteractiveBrowserCredentialOptions{TenantID: t, ClientID: getSqlClientId()})
-	case ActiveDirectoryPassword:
-		cred, err = azidentity.NewUsernamePasswordCredential(t, getSqlClientId(), user, password, nil)
-	case ActiveDirectoryManagedIdentity:
-		cred, err = azidentity.NewManagedIdentityCredential(user, nil)
-	case ActiveDirectoryServicePrincipal:
-		cred, err = azidentity.NewClientSecretCredential(t, user, password, nil)
-	default:
-		// no implementation of AAD Integrated yet
-		cred, err = azidentity.NewDefaultAzureCredential(nil)
-	}
 
+	connectionUrl, err := url.Parse(connstr)
 	if err != nil {
 		return nil, err
 	}
-	resourceUrl := s.getResourceUrl()
-	conn, err := mssql.NewAccessTokenConnector(connstr, func() (string, error) {
-		opts := policy.TokenRequestOptions{Scopes: []string{resourceUrl + scope}}
-		tk, err := cred.GetToken(context.Background(), opts)
-		if err != nil {
-			return "", err
-		}
-		return tk.Token, err
-	})
 
-	return conn, err
+	if user != "" {
+		connectionUrl.User = url.UserPassword(user, password)
+	}
+
+	query := connectionUrl.Query()
+	query.Set("fedauth", s.Connect.authenticationMethod())
+	query.Set("applicationclientid", getSqlClientId())
+
+	switch s.Connect.AuthenticationMethod {
+	case azuread.ActiveDirectoryServicePrincipal:
+	case azuread.ActiveDirectoryApplication:
+		query.Set("clientcertpath", os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH"))
+	case azuread.ActiveDirectoryInteractive:
+		// AAD interactive needs minutes at minimum
+		if s.Connect.LoginTimeoutSeconds < 120 {
+			query.Set("connection timeout", "120")
+		}
+	}
+
+	connectionUrl.RawQuery = query.Encode()
+	return azuread.NewConnector(connectionUrl.String())
 }

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -155,12 +155,14 @@ func TestIncludeFileNoExecutions(t *testing.T) {
 		}
 		file, err = os.CreateTemp("", "sqlcmdout")
 		assert.NoError(t, err, "os.CreateTemp")
+		defer os.Remove(file.Name())
 		s.SetOutput(file)
 		// The second file has a go so it will execute all statements before it
 		err = s.IncludeFile(dataPath+"twobatchnoendinggo.sql", false)
 		if assert.NoError(t, err, "IncludeFile twobatchnoendinggo.sql false") {
 			assert.Equal(t, "-", s.batch.State(), "s.batch.State() after IncludeFile twobatchnoendinggo.sql false")
 			assert.Equal(t, "select 'string' as title", s.batch.String(), "s.batch.String() after IncludeFile twobatchnoendinggo.sql false")
+			s.SetOutput(nil)
 			bytes, err := os.ReadFile(file.Name())
 			if assert.NoError(t, err, "os.ReadFile") {
 				assert.Equal(t, "100"+SqlcmdEol+SqlcmdEol+oneRowAffected+SqlcmdEol+"string"+SqlcmdEol+SqlcmdEol+oneRowAffected+SqlcmdEol+"100"+SqlcmdEol+SqlcmdEol+oneRowAffected+SqlcmdEol, string(bytes), "Incorrect output from Run")


### PR DESCRIPTION
go-sqlcmd doesn't need a custom connector implementation now that `go-mssqldb` has an azuread connector.
I've also cleaned up the test pipeline to actually publish test results.
