### PR TITLE
Implement connect command and password prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ We will be implementing command line switches and behaviors over time. Several s
 - Some behaviors that were kept to maintain compatibility with `OSQL` may be changed, such as alignment of column headers for some data types.
 - All commands must fit on one line, even `EXIT`. Interactive mode will not check for open parentheses or quotes for commands and prompt for successive lines. The ODBC sqlcmd allows the query run by `EXIT(query)` to span multiple lines.
 
+### Miscellaneous enhancements
+
+- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlAuthentication`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` user name parameter.
+- The new `--driver-logging-level` command line parameter allows you to see traces from the `go-mssqldb` client driver. Use `64` to see all traces.
+
 ### Azure Active Directory Authentication
 
 This version of sqlcmd supports a broader range of AAD authentication models, based on the [azidentity package](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity). The implementation relies on an AAD Connector in the [driver](https://github.com/denisenkom/go-mssqldb).

--- a/cmd/sqlcmd/main_test.go
+++ b/cmd/sqlcmd/main_test.go
@@ -122,7 +122,7 @@ func TestRunInputFiles(t *testing.T) {
 	vars.Set(sqlcmd.SQLCMDMAXVARTYPEWIDTH, "0")
 	setVars(vars, &args)
 
-	exitCode, err := run(vars)
+	exitCode, err := run(vars, &args)
 	assert.NoError(t, err, "run")
 	assert.Equal(t, 0, exitCode, "exitCode")
 	bytes, err := os.ReadFile(o.Name())
@@ -148,7 +148,7 @@ func TestQueryAndExit(t *testing.T) {
 	vars.Set("VAR1", "100")
 	setVars(vars, &args)
 
-	exitCode, err := run(vars)
+	exitCode, err := run(vars, &args)
 	assert.NoError(t, err, "run")
 	assert.Equal(t, 0, exitCode, "exitCode")
 	bytes, err := os.ReadFile(o.Name())
@@ -173,8 +173,7 @@ func TestAzureAuth(t *testing.T) {
 	vars := sqlcmd.InitializeVariables(!args.DisableCmdAndWarn)
 	vars.Set(sqlcmd.SQLCMDMAXVARTYPEWIDTH, "0")
 	setVars(vars, &args)
-
-	exitCode, err := run(vars)
+	exitCode, err := run(vars, &args)
 	assert.NoError(t, err, "run")
 	assert.Equal(t, 0, exitCode, "exitCode")
 	bytes, err := os.ReadFile(o.Name())

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/microsoft/go-sqlcmd
 go 1.16
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
 	github.com/alecthomas/kong v0.2.18-0.20210621093454-54558f65e86f
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/test v0.0.0-20210722231415-061457976a23 // indirect
@@ -15,3 +13,4 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
+replace github.com/denisenkom/go-mssqldb => github.com/shueybubbles/go-mssqldb v0.10.1-0.20220303143659-8896461e4ec7

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMn
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisenkom/go-mssqldb v0.12.0 h1:VtrkII767ttSPNRfFekePK3sctr+joXgO58stqQbtUA=
-github.com/denisenkom/go-mssqldb v0.12.0/go.mod h1:iiK0YP1ZeepvmBQk/QpLEhhTNJgfzrpArPY/aFvc9yU=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/gohxs/readline v0.0.0-20171011095936-a780388e6e7c h1:yE35fKFwcelIte3q5q1/cPiY7pI7vvf5/j/0ddxNCKs=
 github.com/gohxs/readline v0.0.0-20171011095936-a780388e6e7c/go.mod h1:9S/fKAutQ6wVHqm1jnp9D9sc5hu689s9AaTWFS92LaU=
@@ -31,6 +29,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shueybubbles/go-mssqldb v0.10.1-0.20220303143659-8896461e4ec7 h1:4CIaYagSRCGr0/Gh6cfF5cQx3RVE3qrQukZn8iMO6Y8=
+github.com/shueybubbles/go-mssqldb v0.10.1-0.20220303143659-8896461e4ec7/go.mod h1:iiK0YP1ZeepvmBQk/QpLEhhTNJgfzrpArPY/aFvc9yU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+
+	"github.com/alecthomas/kong"
 )
 
 // Command defines a sqlcmd action which can be intermixed with the SQL batch
@@ -79,6 +81,11 @@ func newCommands() Commands {
 			regex:  regexp.MustCompile(`(?im)^[ \t]*:LIST(?:[ \t]+(.*$)|$)`),
 			action: listCommand,
 			name:   "LIST",
+		},
+		"CONNECT": {
+			regex:  regexp.MustCompile(`(?im)^[ \t]*:CONNECT(?:[ \t]+(.*$)|$)`),
+			action: connectCommand,
+			name:   "CONNECT",
 		},
 	}
 
@@ -283,5 +290,41 @@ func listCommand(s *Sqlcmd, args []string, line uint) error {
 		fmt.Fprintf(s.GetOutput(), `%s%s`, []byte(s.batch.String()), SqlcmdEol)
 	}
 
+	return nil
+}
+
+type connectData struct {
+	Server               string `arg:""`
+	Database             string `short:"D"`
+	Username             string `short:"U"`
+	Password             string `short:"P"`
+	LoginTimeout         int    `short:"l"`
+	AuthenticationMethod string `short:"G"`
+}
+
+func connectCommand(s *Sqlcmd, args []string, line uint) error {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return InvalidCommandError("CONNECT", line)
+	}
+	arguments := &connectData{}
+	parser, err := kong.New(arguments)
+	if err != nil {
+		return InvalidCommandError("CONNECT", line)
+	}
+	if _, err = parser.Parse(strings.Split(args[0], " ")); err != nil {
+		return InvalidCommandError("CONNECT", line)
+	}
+
+	connect := s.Connect
+	connect.UserName = arguments.Username
+	connect.Password = arguments.Password
+	connect.ServerName = arguments.Server
+	if arguments.LoginTimeout > 0 {
+		connect.LoginTimeoutSeconds = arguments.LoginTimeout
+	}
+	connect.AuthenticationMethod = arguments.AuthenticationMethod
+	// If no user name is provided we switch to integrated auth
+	_ = s.ConnectDb(&connect, s.lineIo == nil)
+	// ConnectDb prints connection errors already, and failure to connect is not fatal even with -b option
 	return nil
 }

--- a/pkg/sqlcmd/connect.go
+++ b/pkg/sqlcmd/connect.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package sqlcmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/denisenkom/go-mssqldb/azuread"
+)
+
+// ConnectSettings specifies the settings for connections
+type ConnectSettings struct {
+	// ServerName is the full name including instance and port
+	ServerName string
+	// UseTrustedConnection indicates integrated auth is used when no user name is provided
+	UseTrustedConnection bool
+	// TrustServerCertificate sets the TrustServerCertificate setting on the connection string
+	TrustServerCertificate bool
+	// AuthenticationMethod defines the authentication method for connecting to Azure SQL Database
+	AuthenticationMethod string
+	// DisableEnvironmentVariables determines if sqlcmd resolves scripting variables from the process environment
+	DisableEnvironmentVariables bool
+	// DisableVariableSubstitution determines if scripting variables should be evaluated
+	DisableVariableSubstitution bool
+	// UserName is the username for the SQL connection
+	UserName string
+	// Password is the password used with SQL authentication or AAD authentications that require a password
+	Password string
+	// Encrypt is the choice of encryption
+	Encrypt string
+	// PacketSize is the size of the packet for TDS communication
+	PacketSize int
+	// LoginTimeoutSeconds specifies the timeout for establishing a connection
+	LoginTimeoutSeconds int
+	// WorkstationName is the string to use to identify the host in server DMVs
+	WorkstationName string
+	// ApplicationIntent can only be empty or "ReadOnly"
+	ApplicationIntent string
+	// LogLevel is the mssql driver log level
+	LogLevel int
+	// ExitOnError specifies whether to exit the app on an error
+	ExitOnError bool
+	// ErrorSeverityLevel sets the minimum SQL severity level to treat as an error
+	ErrorSeverityLevel uint8
+	// Database is the name of the database for the connection
+	Database string
+}
+
+func (c ConnectSettings) authenticationMethod() string {
+	if c.AuthenticationMethod == "" {
+		return NotSpecified
+	}
+	return c.AuthenticationMethod
+}
+
+func (connect ConnectSettings) integratedAuthentication() bool {
+	return connect.UseTrustedConnection || (connect.UserName == "" && connect.authenticationMethod() == NotSpecified)
+}
+
+func (connect ConnectSettings) sqlAuthentication() bool {
+	return connect.authenticationMethod() == SqlPassword ||
+		(!connect.UseTrustedConnection && connect.authenticationMethod() == NotSpecified && connect.UserName != "")
+}
+
+func (connect ConnectSettings) requiresPassword() bool {
+	requiresPassword := connect.sqlAuthentication()
+	if !requiresPassword {
+		switch connect.authenticationMethod() {
+		case azuread.ActiveDirectoryApplication, azuread.ActiveDirectoryPassword, azuread.ActiveDirectoryServicePrincipal:
+			requiresPassword = true
+		}
+	}
+	return requiresPassword
+}
+
+// ConnectionString returns the go-mssql connection string to use for queries
+func (connect ConnectSettings) ConnectionString() (connectionString string, err error) {
+	serverName, instance, port, err := splitServer(connect.ServerName)
+	if serverName == "" {
+		serverName = "."
+	}
+	if err != nil {
+		return "", err
+	}
+	query := url.Values{}
+	connectionURL := &url.URL{
+		Scheme: "sqlserver",
+		Path:   instance,
+	}
+
+	if connect.sqlAuthentication() || connect.authenticationMethod() == azuread.ActiveDirectoryPassword || connect.authenticationMethod() == azuread.ActiveDirectoryServicePrincipal || connect.authenticationMethod() == azuread.ActiveDirectoryApplication {
+		connectionURL.User = url.UserPassword(connect.UserName, connect.Password)
+	}
+	if (connect.authenticationMethod() == azuread.ActiveDirectoryMSI || connect.authenticationMethod() == azuread.ActiveDirectoryManagedIdentity) && connect.UserName != "" {
+		connectionURL.User = url.UserPassword(connect.UserName, connect.Password)
+	}
+	if port > 0 {
+		connectionURL.Host = fmt.Sprintf("%s:%d", serverName, port)
+	} else {
+		connectionURL.Host = serverName
+	}
+	if connect.Database != "" {
+		query.Add("database", connect.Database)
+	}
+
+	if connect.TrustServerCertificate {
+		query.Add("trustservercertificate", "true")
+	}
+	if connect.ApplicationIntent != "" && connect.ApplicationIntent != "default" {
+		query.Add("applicationintent", connect.ApplicationIntent)
+	}
+	if connect.LoginTimeoutSeconds > 0 {
+		query.Add("connection timeout", fmt.Sprint(connect.LoginTimeoutSeconds))
+	}
+	if connect.PacketSize > 0 {
+		query.Add("packet size", fmt.Sprint(connect.PacketSize))
+	}
+	if connect.WorkstationName != "" {
+		query.Add("workstation id", connect.WorkstationName)
+	}
+	if connect.Encrypt != "" && connect.Encrypt != "default" {
+		query.Add("encrypt", connect.Encrypt)
+	}
+	if connect.LogLevel > 0 {
+		query.Add("log", fmt.Sprint(connect.LogLevel))
+	}
+	connectionURL.RawQuery = query.Encode()
+	return connectionURL.String(), nil
+}

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -56,7 +56,7 @@ func TestCalcColumnDetails(t *testing.T) {
 		},
 	}
 
-	db, err := ConnectDb()
+	db, err := ConnectDb(t)
 	if assert.NoError(t, err, "ConnectDB failed") {
 		defer db.Close()
 		for _, test := range tests {

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/signal"
 	osuser "os/user"
@@ -20,7 +19,6 @@ import (
 	"syscall"
 
 	mssql "github.com/denisenkom/go-mssqldb"
-	"github.com/denisenkom/go-mssqldb/azuread"
 	"github.com/denisenkom/go-mssqldb/msdsn"
 	"github.com/golang-sql/sqlexp"
 )
@@ -42,126 +40,6 @@ type Console interface {
 	ReadPassword(prompt string) ([]byte, error)
 	// SetPrompt sets the prompt text shown to input the next line
 	SetPrompt(s string)
-}
-
-// ConnectSettings specifies the settings for connections
-type ConnectSettings struct {
-	// ServerName is the full name including instance and port
-	ServerName string
-	// UseTrustedConnection indicates integrated auth is used when no user name is provided
-	UseTrustedConnection bool
-	// TrustServerCertificate sets the TrustServerCertificate setting on the connection string
-	TrustServerCertificate bool
-	// AuthenticationMethod defines the authentication method for connecting to Azure SQL Database
-	AuthenticationMethod string
-	// DisableEnvironmentVariables determines if sqlcmd resolves scripting variables from the process environment
-	DisableEnvironmentVariables bool
-	// DisableVariableSubstitution determines if scripting variables should be evaluated
-	DisableVariableSubstitution bool
-	// UserName is the username for the SQL connection
-	UserName string
-	// Password is the password used with SQL authentication or AAD authentications that require a password
-	Password string
-	// Encrypt is the choice of encryption
-	Encrypt string
-	// PacketSize is the size of the packet for TDS communication
-	PacketSize int
-	// LoginTimeoutSeconds specifies the timeout for establishing a connection
-	LoginTimeoutSeconds int
-	// WorkstationName is the string to use to identify the host in server DMVs
-	WorkstationName string
-	// ApplicationIntent can only be empty or "ReadOnly"
-	ApplicationIntent string
-	// LogLevel is the mssql driver log level
-	LogLevel int
-	// ExitOnError specifies whether to exit the app on an error
-	ExitOnError bool
-	// ErrorSeverityLevel sets the minimum SQL severity level to treat as an error
-	ErrorSeverityLevel uint8
-	// Database is the name of the database for the connection
-	Database string
-}
-
-func (c ConnectSettings) authenticationMethod() string {
-	if c.AuthenticationMethod == "" {
-		return NotSpecified
-	}
-	return c.AuthenticationMethod
-}
-
-func (connect ConnectSettings) integratedAuthentication() bool {
-	return connect.UseTrustedConnection || (connect.UserName == "" && connect.authenticationMethod() == NotSpecified)
-}
-
-func (connect ConnectSettings) sqlAuthentication() bool {
-	return connect.authenticationMethod() == SqlPassword ||
-		(!connect.UseTrustedConnection && connect.authenticationMethod() == NotSpecified && connect.UserName != "")
-}
-
-func (connect ConnectSettings) requiresPassword() bool {
-	requiresPassword := connect.sqlAuthentication()
-	if !requiresPassword {
-		switch connect.authenticationMethod() {
-		case azuread.ActiveDirectoryApplication, azuread.ActiveDirectoryPassword, azuread.ActiveDirectoryServicePrincipal:
-			requiresPassword = true
-		}
-	}
-	return requiresPassword
-}
-
-// ConnectionString returns the go-mssql connection string to use for queries
-func (connect ConnectSettings) ConnectionString() (connectionString string, err error) {
-	serverName, instance, port, err := splitServer(connect.ServerName)
-	if serverName == "" {
-		serverName = "."
-	}
-	if err != nil {
-		return "", err
-	}
-	query := url.Values{}
-	connectionURL := &url.URL{
-		Scheme: "sqlserver",
-		Path:   instance,
-	}
-
-	if connect.sqlAuthentication() || connect.authenticationMethod() == azuread.ActiveDirectoryPassword || connect.authenticationMethod() == azuread.ActiveDirectoryServicePrincipal || connect.authenticationMethod() == azuread.ActiveDirectoryApplication {
-		connectionURL.User = url.UserPassword(connect.UserName, connect.Password)
-	}
-	if (connect.authenticationMethod() == azuread.ActiveDirectoryMSI || connect.authenticationMethod() == azuread.ActiveDirectoryManagedIdentity) && connect.UserName != "" {
-		connectionURL.User = url.UserPassword(connect.UserName, connect.Password)
-	}
-	if port > 0 {
-		connectionURL.Host = fmt.Sprintf("%s:%d", serverName, port)
-	} else {
-		connectionURL.Host = serverName
-	}
-	if connect.Database != "" {
-		query.Add("database", connect.Database)
-	}
-
-	if connect.TrustServerCertificate {
-		query.Add("trustservercertificate", "true")
-	}
-	if connect.ApplicationIntent != "" && connect.ApplicationIntent != "default" {
-		query.Add("applicationintent", connect.ApplicationIntent)
-	}
-	if connect.LoginTimeoutSeconds > 0 {
-		query.Add("connection timeout", fmt.Sprint(connect.LoginTimeoutSeconds))
-	}
-	if connect.PacketSize > 0 {
-		query.Add("packet size", fmt.Sprint(connect.PacketSize))
-	}
-	if connect.WorkstationName != "" {
-		query.Add("workstation id", connect.WorkstationName)
-	}
-	if connect.Encrypt != "" && connect.Encrypt != "default" {
-		query.Add("encrypt", connect.Encrypt)
-	}
-	if connect.LogLevel > 0 {
-		query.Add("log", fmt.Sprint(connect.LogLevel))
-	}
-	connectionURL.RawQuery = query.Encode()
-	return connectionURL.String(), nil
 }
 
 // Sqlcmd is the core processor for text lines.
@@ -395,8 +273,8 @@ func (s *Sqlcmd) promptPassword() (string, error) {
 	return string(pwd), nil
 }
 
-// IncludeFile opens the given file and processes its batches
-// When processAll is true text not followed by a go statement is run as a query
+// IncludeFile opens the given file and processes its batches.
+// When processAll is true, text not followed by a go statement is run as a query
 func (s *Sqlcmd) IncludeFile(path string, processAll bool) error {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
`:Connect` implementation uses the same command line parser as `main`. I've added a `-G` to enable AAD auth. 
I've also created a `Console` interface to enable future replacement of `readline` with something more modern.
Fixes #50 