### PR TITLE
Debian(Buster/Stretch/Jessie)/Ubuntu(Focal/Bionic/Xenial)/Apt packages

### DIFF
--- a/build/azure-pipelines/package-product.yml
+++ b/build/azure-pipelines/package-product.yml
@@ -15,7 +15,11 @@ stages:
           rpm:
             imageName: 'ubuntu-latest'
             os: linux
-            type: rpm    
+            type: rpm
+          debian:
+            imageName: 'ubuntu-latest'
+            os: linux
+            type: deb
       pool:
         vmImage: $(imageName)
       steps:
@@ -27,4 +31,3 @@ stages:
           parameters:
             OS: $(os)
             Type: $(type)
-

--- a/release/linux/deb/README.md
+++ b/release/linux/deb/README.md
@@ -1,0 +1,84 @@
+# Debian Packaging Release
+
+## Building the Debian package
+
+Execute the following command from the root directory of this repository:
+
+``` bash
+./release/linux/debian/pipeline.sh
+```
+
+Output will be sent to `./output/debian`
+
+## Dev Installation and Verification
+
+``` bash
+./release/linux/debian/pipeline-test.sh
+```
+
+## Release Install/Update/Uninstall Steps
+
+> **Note:** Replace `{{HOST}}` and `{{CLI_VERSION}}` with the appropriate values.
+
+### Install sqlcmd with apt (Ubuntu or Debian)
+
+1. Download and install the signing key:
+
+```bash
+sudo curl -sL http://{{HOST}}/browse/repo/ubuntu/dpgswdist.v1.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/dpgswdist.v1.asc.gpg > /dev/null
+```
+
+2. Add the sqlcmd repository information:
+
+```bash
+sudo echo "deb [trusted=yes arch=amd64] http://{{HOST}}/browse/repo/ubuntu/sqlcmd mssql main" | tee /etc/apt/sources.list.d/sqlcmd.list
+```
+
+3. Update repository information and install sqlcmd:
+
+```bash
+sudo apt-get update
+sudo apt-get install sqlcmd
+```
+
+5. Verify installation success:
+
+```bash
+sqlcmd --help
+```
+
+### Update
+
+1. Upgrade sqlcmd only:
+
+```bash
+sudo apt-get update && sudo apt-get install --only-upgrade -y sqlcmd
+```
+
+### Uninstall
+
+1. Uninstall with apt-get remove:
+
+```bash
+sudo apt-get remove -y sqlcmd
+```
+
+2. Remove the sqlcmd repository information:
+
+> Note: This step is not needed if you plan on installing sqlcmd in the future
+
+```bash
+sudo rm /etc/apt/sources.list.d/sqlcmd.list
+```
+
+3. Remove the signing key:
+
+```bash
+sudo rm /etc/apt/trusted.gpg.d/dpgswdist.v1.asc.gpg
+```
+
+4. Remove any unneeded dependencies that were installed with sqlcmd:
+
+```bash
+sudo apt autoremove
+```

--- a/release/linux/deb/build-pkg.sh
+++ b/release/linux/deb/build-pkg.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+#------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#------------------------------------------------------------------------------
+
+# Description:
+#
+# Build a debian/ubuntu `sqlcmd` package. This script is intended to be ran in a
+# container with the respective disto/image laid down.
+#
+# Usage:
+# $ build-pkg.sh
+
+set -exv
+
+: "${CLI_VERSION:?CLI_VERSION environment variable not set.}"
+: "${CLI_VERSION_REVISION:?CLI_VERSION_REVISION environment variable not set.}"
+
+WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
+
+ls -la ${WORKDIR}
+
+apt-get -y update || exit 1
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y \
+  debhelper \
+  dpkg-dev \
+  locales || exit 1
+
+# Locale
+sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+export LANG=en_US.UTF-8
+export PATH=$PATH
+
+# Verify
+chmod u+x /mnt/workspace/sqlcmd
+/mnt/workspace/sqlcmd --help
+
+mkdir /opt/stage
+cp /mnt/workspace/sqlcmd /opt/stage/sqlcmd
+
+# Create create directory for debian build
+mkdir -p ${WORKDIR}/debian
+${WORKDIR}/release/linux/deb/prepare-rules.sh ${WORKDIR}/debian ${WORKDIR}
+
+cd ${WORKDIR}
+dpkg-buildpackage -us -uc
+
+ls ${WORKDIR} -R
+
+debPkg=${WORKDIR}/../sqlcmd_${CLI_VERSION}-${CLI_VERSION_REVISION:=1}_all.deb
+cp ${debPkg} /mnt/output/

--- a/release/linux/deb/pipeline-test.sh
+++ b/release/linux/deb/pipeline-test.sh
@@ -33,7 +33,7 @@ CLI_VERSION=${CLI_VERSION:=0.0.1}
 CLI_VERSION_REVISION=${CLI_VERSION_REVISION:=1}
 BUILD_ARTIFACTSTAGINGDIRECTORY=${BUILD_ARTIFACTSTAGINGDIRECTORY:=${REPO_ROOT_DIR}/output/debian}
 
-DISTROS=( buster focal ) # TODO: Should we validate against more distros?: buster stretch jessie bionic xenial focal
+DISTROS=( buster buster ) # TODO: Should we validate against more distros?: buster stretch jessie bionic xenial focal
 BASE_IMAGES=( debian:buster ubuntu:focal ) # TODO: debian:buster debian:stretch debian:jessie ubuntu:bionic ubuntu:xenial ubuntu:focal
 
 echo "=========================================================="

--- a/release/linux/deb/pipeline-test.sh
+++ b/release/linux/deb/pipeline-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+#------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#------------------------------------------------------------------------------
+
+# Description:
+#
+# Instructions to be invoked under the build CI pipeline in AzureDevOps.
+#
+# Kickoff Debian package tests against versions:
+#
+# Usage:
+# -----------------------------------
+# buster  - Debian 10
+# stretch - Debian 9
+# jessie  - Debian 8
+# -----------------------------------
+# focal  - Ubuntu 20.04
+# bionic - Ubuntu 18.04
+# xenial - Ubuntu 16.04
+# -----------------------------------
+#
+# Usage:
+# $ pipeline-test.sh
+
+set -e #xv
+
+: "${REPO_ROOT_DIR:=`cd $(dirname $0); cd ../../../; pwd`}"
+
+CLI_VERSION=${CLI_VERSION:=0.0.1}
+CLI_VERSION_REVISION=${CLI_VERSION_REVISION:=1}
+BUILD_ARTIFACTSTAGINGDIRECTORY=${BUILD_ARTIFACTSTAGINGDIRECTORY:=${REPO_ROOT_DIR}/output/debian}
+
+DISTROS=( buster focal ) # TODO: Should we validate against more distros?: buster stretch jessie bionic xenial focal
+BASE_IMAGES=( debian:buster ubuntu:focal ) # TODO: debian:buster debian:stretch debian:jessie ubuntu:bionic ubuntu:xenial ubuntu:focal
+
+echo "=========================================================="
+echo "CLI_VERSION: ${CLI_VERSION}"
+echo "CLI_VERSION_REVISION: ${CLI_VERSION_REVISION}"
+echo "BUILD_ARTIFACTSTAGINGDIRECTORY: ${BUILD_ARTIFACTSTAGINGDIRECTORY}"
+echo "Distribution: ${DISTROS}"
+echo "=========================================================="
+
+for i in ${!DISTROS[@]}; do
+    echo "=========================================================="
+    echo "Test debian package on ${DISTROS[$i]}"
+    echo "=========================================================="
+
+    debPkg=sqlcmd_${CLI_VERSION}-${CLI_VERSION_REVISION}~${DISTROS[$i]}_all.deb
+
+    script="apt-get update && \
+            dpkg -i /mnt/artifacts/${debPkg} && \
+            apt-get -f install && \
+            sqlcmd --help"
+
+    docker pull ${BASE_IMAGES[$i]}
+    docker run --rm -v ${BUILD_ARTIFACTSTAGINGDIRECTORY}:/mnt/artifacts \
+               ${BASE_IMAGES[$i]} \
+               /bin/bash -c "${script}"
+
+    echo ""
+done

--- a/release/linux/deb/pipeline.sh
+++ b/release/linux/deb/pipeline.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+#------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#------------------------------------------------------------------------------
+
+# Description:
+#
+# Instructions to be invoked under the build CI pipeline in AzureDevOps.
+#
+# Kickoff debian package build in docker and copy the .deb package artifact
+# back to the local filesystem. The build pipeline can then save it as an
+# artifact as it sees fit.
+#
+# Note: Intended to be ran under ubuntu.
+#
+# Usage:
+# -----------------------------------
+# buster  - Debian 10
+# stretch - Debian 9
+# jessie  - Debian 8
+# -----------------------------------
+# focal  - Ubuntu 20.04
+# bionic - Ubuntu 18.04
+# xenial - Ubuntu 16.04
+# -----------------------------------
+#
+# Example:
+#
+# export DISTRO=xenial
+# export DISTRO_BASE_IMAGE=ubuntu:xenial
+#
+# $ pipeline.sh
+
+set -exv
+
+DISTRO=${DISTRO:=buster}
+DISTRO_BASE_IMAGE=${DISTRO_BASE_IMAGE:=debian:buster}
+
+: "${DISTRO:?DISTRO environment variable not set.}"
+: "${DISTRO_BASE_IMAGE:?DISTRO_BASE_IMAGE environment variable not set.}"
+: "${REPO_ROOT_DIR:=`cd $(dirname $0); cd ../../../; pwd`}"
+DIST_DIR=${BUILD_STAGINGDIRECTORY:=${REPO_ROOT_DIR}/output/debian}
+
+PIPELINE_WORKSPACE=${REPO_ROOT_DIR}
+
+if [[ "${BUILD_OUTPUT}" != "" ]]; then
+    cp ${BUILD_OUTPUT}/SqlcmdLinuxAmd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
+fi
+
+CLI_VERSION=${CLI_VERSION:=0.0.1}
+
+echo "=========================================================="
+echo "CLI_VERSION: ${CLI_VERSION}"
+echo "CLI_VERSION_REVISION: ${CLI_VERSION_REVISION:=1}"
+echo "Distribution: ${DISTRO}"
+echo "Distribution Image: ${DISTRO_BASE_IMAGE}"
+echo "=========================================================="
+
+mkdir -p ${DIST_DIR} || exit 1
+
+echo ${REPO_ROOT_DIR}
+
+docker run --rm \
+           -v "${REPO_ROOT_DIR}":/mnt/repo \
+           -v "${DIST_DIR}":/mnt/output \
+           -v "${PIPELINE_WORKSPACE}":/mnt/workspace \
+           -e CLI_VERSION=${CLI_VERSION} \
+           -e CLI_VERSION_REVISION=${CLI_VERSION_REVISION:=1}~${DISTRO} \
+           "${DISTRO_BASE_IMAGE}" \
+           /mnt/repo/release/linux/deb/build-pkg.sh

--- a/release/linux/deb/prepare-rules.sh
+++ b/release/linux/deb/prepare-rules.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+#------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#------------------------------------------------------------------------------
+
+# Description:
+#
+# Create the debian/directory for building the `sqlcmd` Debian package and
+# the package rules.
+#
+# Usage:
+#
+# prepare-rules.sh DEBIAN-DIR SRC_DIR
+#
+
+set -evx
+
+if [[ -z "$1" ]]
+  then
+    echo "No argument supplied for debian directory."
+    exit 1
+fi
+
+if [[ -z "$2" ]]
+  then
+    echo "No argument supplied for source directory."
+    exit 1
+fi
+
+TAB=$'\t'
+
+debian_dir=$1
+source_dir=$2
+
+mkdir -p $debian_dir/source || exit 1
+
+echo '1.0' > $debian_dir/source/format
+echo '9' > $debian_dir/compat
+
+cat > $debian_dir/changelog <<- EOM
+sqlcmd (${CLI_VERSION}-${CLI_VERSION_REVISION:=1}) stable; urgency=low
+
+  * Debian package release.
+
+ -- sqlcmd tools team <dpgswdist@microsoft.com@microsoft.com>  $(date -R)
+
+EOM
+
+cat > $debian_dir/control <<- EOM
+Source: sqlcmd
+Section: sql
+Priority: extra
+Maintainer: sqlcmd tools team <dpgswdist@microsoft.com>
+Build-Depends: debhelper (>= 9)
+Standards-Version: 3.9.5
+Homepage: https://github.com/microsoft/go-sqlcmd
+
+Package: sqlcmd
+Architecture: all
+Depends: \${shlibs:Depends}, \${misc:Depends}
+Description: SQLCMD TOOLS CLI
+ SQLCMD TOOLS CLI, a multi-platform command line experience for Microsoft SQL Server and Azure SQL.
+
+EOM
+
+cat > $debian_dir/copyright <<- EOM
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: sqlcmd
+Upstream-Contact: sqlcmd tools team <dpgswdist@microsoft.com>
+Source: PUBLIC
+
+Files: *
+Copyright: Copyright (c) Microsoft Corporation
+License: https://github.com/microsoft/go-sqlcmd/blob/main/LICENSE
+
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+EOM
+
+cat > $debian_dir/rules << EOM
+#!/usr/bin/make -f
+
+# Uncomment this to turn on verbose mode.
+export DH_VERBOSE=1
+export DH_OPTIONS=-v
+
+%:
+${TAB}dh \$@ --sourcedirectory $source_dir
+
+override_dh_install:
+${TAB}mkdir -p debian/sqlcmd/usr/bin/
+${TAB}cp -r /opt/stage/sqlcmd debian/sqlcmd/usr/bin/sqlcmd
+${TAB}chmod 0755 debian/sqlcmd/usr/bin/sqlcmd
+
+override_dh_strip:
+${TAB}dh_strip --exclude=_cffi_backend
+
+EOM
+
+cat $debian_dir/rules
+
+# Debian rules should be executable
+chmod 0755 $debian_dir/rules

--- a/release/linux/rpm/README.md
+++ b/release/linux/rpm/README.md
@@ -15,4 +15,3 @@ To test the packages:
 ./release/linux/rpm/pipeline-test.sh
 ```
 
-


### PR DESCRIPTION
This PR builds and signs the sqlcmd .deb package for Apt-get (Ubuntu/Debian) and tests the package for the following base images: debian:buster ubuntu:focal

The PR is designed to work both directly in the local repo and Azure Dev Ops.

This PR is part of a series of 5 initial PRs that will provide packages for all the common managers on the common OSes (Linux, Windows and Mac). Follow up PRs will provide packages for less common configs.

Execute the following command from the root directory of this repository:

./release/linux/deb/pipeline.sh

Output will be sent to ./output/deb

To test the packages:

./release/linux/deb/pipeline-test.sh

A follow up PR will publish the .debs to packages.microsoft.com for public download