### PR TITLE
use correct divider for instance name

### DIFF
--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -41,7 +41,7 @@ func TestConnectionStringFromSqlCmd(t *testing.T) {
 			"sqlserver://.?database=somedatabase&encrypt=false&workstation+id=mystation",
 		},
 		{
-			&ConnectSettings{TrustServerCertificate: true, Password: pwd, ServerName: `someserver/instance`, Database: "somedatabase", UserName: "someuser"},
+			&ConnectSettings{TrustServerCertificate: true, Password: pwd, ServerName: `someserver\instance`, Database: "somedatabase", UserName: "someuser"},
 			fmt.Sprintf("sqlserver://someuser:%s@someserver/instance?database=somedatabase&trustservercertificate=true", pwd),
 		},
 		{

--- a/pkg/sqlcmd/util.go
+++ b/pkg/sqlcmd/util.go
@@ -30,7 +30,7 @@ func splitServer(serverName string) (string, string, uint64, error) {
 		}
 		serverName = serverNameParts[0]
 	} else {
-		serverNameParts = strings.Split(serverName, "/")
+		serverNameParts = strings.Split(serverName, "\\")
 		if len(serverNameParts) > 2 {
 			return "", "", 0, &InvalidServerName
 		}

--- a/pkg/sqlcmd/variables_test.go
+++ b/pkg/sqlcmd/variables_test.go
@@ -47,10 +47,10 @@ func TestEnvironmentVariablesAsInput(t *testing.T) {
 
 func TestSqlServerSplitsName(t *testing.T) {
 	vars := Variables{
-		SQLCMDSERVER: `tcp:someserver/someinstance`,
+		SQLCMDSERVER: `tcp:someserver\someinstance`,
 	}
 	serverName, instance, port, err := vars.SQLCmdServer()
-	if assert.NoError(t, err, "tcp:server/someinstance") {
+	if assert.NoError(t, err, "tcp:server\\someinstance") {
 		assert.Equal(t, "someserver", serverName, "server name for instance")
 		assert.Equal(t, uint64(0), port, "port for instance")
 		assert.Equal(t, "someinstance", instance, "instance for instance")


### PR DESCRIPTION
Fixes #66 
Current code uses the wrong separator for server\instance connection strings.

