### PR TITLE
do not treat \ as escape character in strings

### DIFF
--- a/pkg/sqlcmd/batch.go
+++ b/pkg/sqlcmd/batch.go
@@ -242,10 +242,6 @@ func (b *Batch) readString(r []rune, i, end int, quote rune, line uint) (int, bo
 			} else {
 				return i, false, syntaxError(line)
 			}
-		case quote == '\'' && c == '\\':
-			i++
-			prev = 0
-			continue
 		case quote == '\'' && c == '\'' && next == '\'':
 			i++
 			continue

--- a/pkg/sqlcmd/batch_test.go
+++ b/pkg/sqlcmd/batch_test.go
@@ -117,6 +117,7 @@ func TestReadString(t *testing.T) {
 		// double quoted string
 		{`"str\""`, 0, `"str\"`, true},
 		{` "str\"" `, 1, `"str\"`, true},
+		{`'str\'`, 0, `'str\'`, true},
 		{`''''`, 0, `''''`, true},
 		{` '''' `, 1, `''''`, true},
 		{`''''''`, 0, `''''''`, true},


### PR DESCRIPTION
I don't know why I put this code in batch.go in the first place.

Fixes #95 