### PR TITLE
Raise error for missing input file

### DIFF
--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -266,6 +266,8 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	} else {
 		for f := range args.InputFile {
 			if err = s.IncludeFile(args.InputFile[f], true); err != nil {
+				s.Exitcode = 1
+				_, _ = os.Stderr.Write([]byte(err.Error()))
 				break
 			}
 		}

--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -266,8 +266,8 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	} else {
 		for f := range args.InputFile {
 			if err = s.IncludeFile(args.InputFile[f], true); err != nil {
+				_, _ = os.Stderr.Write([]byte(err.Error() + sqlcmd.SqlcmdEol))
 				s.Exitcode = 1
-				_, _ = os.Stderr.Write([]byte(err.Error()))
 				break
 			}
 		}

--- a/cmd/sqlcmd/main_test.go
+++ b/cmd/sqlcmd/main_test.go
@@ -323,6 +323,7 @@ func TestMissingInputFile(t *testing.T) {
 
 	exitCode, err := run(vars, &args)
 	assert.Error(t, err, "run")
+	assert.Contains(t, err.Error(), "Error occurred while opening or operating on file", "Unexpected error: "+err.Error())
 	assert.Equal(t, 1, exitCode, "exitCode")
 }
 

--- a/cmd/sqlcmd/main_test.go
+++ b/cmd/sqlcmd/main_test.go
@@ -310,6 +310,22 @@ func TestAzureAuth(t *testing.T) {
 	}
 }
 
+func TestMissingInputFile(t *testing.T) {
+	args = newArguments()
+	args.InputFile = []string{"testdata/missingFile.sql"}
+
+	if canTestAzureAuth() {
+		args.UseAad = true
+	}
+
+	vars := sqlcmd.InitializeVariables(!args.DisableCmdAndWarn)
+	setVars(vars, &args)
+
+	exitCode, err := run(vars, &args)
+	assert.Error(t, err, "run")
+	assert.Equal(t, 1, exitCode, "exitCode")
+}
+
 // Assuming public Azure, use AAD when SQLCMDUSER environment variable is not set
 func canTestAzureAuth() bool {
 	server := os.Getenv(sqlcmd.SQLCMDSERVER)

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -286,7 +286,7 @@ func (s *Sqlcmd) promptPassword() (string, error) {
 func (s *Sqlcmd) IncludeFile(path string, processAll bool) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return InvalidFileError(err, path)
 	}
 	defer f.Close()
 	b := s.batch.batchline


### PR DESCRIPTION
**Summary:**
This PR addresses the issue #101.
An appropriate exit code has been set and error is printed if the input file specified for '-i' is missing.

**Validation**
```
go-sqlcmd>sqlcmd.exe -i missing.sql >stdout.txt 2>stderr.txt

go-sqlcmd>type stderr.txt
Sqlcmd: Error:  Error occurred while opening or operating on file missing.sql (Reason: open missing.sql: The system cannot find the file specified.).

go-sqlcmd>echo %ERRORLEVEL%
1

```