### PR TITLE
Add newline for stderr messages

### DIFF
--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -242,7 +242,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 		if args.ErrorsToStderr >= 0 {
 			s.PrintError = func(msg string, severity uint8) bool {
 				if severity >= stderrSeverity {
-					_, _ = os.Stderr.Write([]byte(msg))
+					_, _ = os.Stderr.Write([]byte(msg + sqlcmd.SqlcmdEol))
 					return true
 				}
 				return false


### PR DESCRIPTION
This commit addresses issue #102.
stderr messages when redirected to stdout would not contain the EOL, causing the prompt to appear on the line as the stderr message.

With existing go-sqlcmd
```
$ sqlcmd -r0
1> select @@version1
2> go
Must declare the scalar variable "@@version1".1>
```
After the changes in PR
```
git\go-sqlcmd>sqlcmd -r0
1> select @@version1
2> go
Must declare the scalar variable "@@version1".
1>
```