### PR TITLE
Initialize console if -U is specified

### DIFF
--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -208,8 +208,9 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	}
 
 	iactive := args.InputFile == nil && args.Query == ""
+	uactive := args.UserName != ""
 	var line sqlcmd.Console = nil
-	if iactive {
+	if iactive || uactive {
 		line = console.NewConsole("")
 		defer line.Close()
 	}
@@ -257,7 +258,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 		s.Query = args.Query
 	}
 	// connect using no overrides
-	err = s.ConnectDb(nil, !iactive)
+	err = s.ConnectDb(nil, line == nil)
 	if err != nil {
 		return 1, err
 	}

--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -201,6 +201,10 @@ func setConnect(connect *sqlcmd.ConnectSettings, args *SQLCmdArguments, vars *sq
 	connect.ErrorSeverityLevel = args.ErrorSeverityLevel
 }
 
+type allocConsole func(historyFile string) sqlcmd.Console
+
+var consoleAllocator allocConsole = console.NewConsole
+
 func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -211,7 +215,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	uactive := args.UserName != ""
 	var line sqlcmd.Console = nil
 	if iactive || uactive {
-		line = console.NewConsole("")
+		line = consoleAllocator("")
 		defer line.Close()
 	}
 

--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -201,7 +201,7 @@ func setConnect(connect *sqlcmd.ConnectSettings, args *SQLCmdArguments, vars *sq
 	connect.ErrorSeverityLevel = args.ErrorSeverityLevel
 }
 
-func IsConsoleInitializationRequired(connect *sqlcmd.ConnectSettings, args *SQLCmdArguments) bool {
+func isConsoleInitializationRequired(connect *sqlcmd.ConnectSettings, args *SQLCmdArguments) bool {
 	iactive := args.InputFile == nil && args.Query == ""
 	return iactive || connect.RequiresPassword()
 }
@@ -215,7 +215,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	var connectConfig sqlcmd.ConnectSettings
 	setConnect(&connectConfig, args, vars)
 	var line sqlcmd.Console = nil
-	if IsConsoleInitializationRequired(&connectConfig, args) {
+	if isConsoleInitializationRequired(&connectConfig, args) {
 		line = console.NewConsole("")
 		defer line.Close()
 	}

--- a/cmd/sqlcmd/main_test.go
+++ b/cmd/sqlcmd/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/kong"
+	"github.com/microsoft/go-mssqldb/azuread"
 	"github.com/microsoft/go-sqlcmd/pkg/sqlcmd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -329,23 +330,50 @@ func TestMissingInputFile(t *testing.T) {
 
 func TestConditionsForPasswordPrompt(t *testing.T) {
 
-	args := newArguments()
-	args.InputFile = []string{"testdata/someFile.sql"}
-	args.DisableCmdAndWarn = true
-	vars := sqlcmd.InitializeVariables(!args.DisableCmdAndWarn)
-	setVars(vars, &args)
-	var connectConfig sqlcmd.ConnectSettings
-	setConnect(&connectConfig, &args, vars)
-	assert.Equal(t, false, IsConsoleInitializationRequired(&connectConfig, &args), "Console initialization was not required")
-	assert.Equal(t, false, connectConfig.RequiresPassword() && connectConfig.Password == "", "Expected value for password prompt condition did not match")
+	type test struct {
+		authenticationMethod string
+		inputFile            []string
+		username             string
+		pwd                  string
+		expectedResult       bool
+	}
+	tests := []test{
+		// Positive Testcases
+		{sqlcmd.SqlPassword, []string{""}, "someuser", "", true},
+		{sqlcmd.NotSpecified, []string{"testdata/someFile.sql"}, "someuser", "", true},
+		{azuread.ActiveDirectoryPassword, []string{""}, "someuser", "", true},
+		{azuread.ActiveDirectoryPassword, []string{"testdata/someFile.sql"}, "someuser", "", true},
+		{azuread.ActiveDirectoryServicePrincipal, []string{""}, "someuser", "", true},
+		{azuread.ActiveDirectoryServicePrincipal, []string{"testdata/someFile.sql"}, "someuser", "", true},
+		{azuread.ActiveDirectoryApplication, []string{""}, "someuser", "", true},
+		{azuread.ActiveDirectoryApplication, []string{"testdata/someFile.sql"}, "someuser", "", true},
 
-	args.InputFile = []string{"testdata/someFile.sql"}
-	args.UserName = "someuser"
-	vars = sqlcmd.InitializeVariables(!args.DisableCmdAndWarn)
-	setVars(vars, &args)
-	setConnect(&connectConfig, &args, vars)
-	assert.Equal(t, true, IsConsoleInitializationRequired(&connectConfig, &args), "Console initialization was not required")
-	assert.Equal(t, true, connectConfig.RequiresPassword() && connectConfig.Password == "", "Expected value for password prompt condition did not match")
+		//Negative Testcases
+		{sqlcmd.NotSpecified, []string{""}, "", "", false},
+		{sqlcmd.NotSpecified, []string{"testdata/someFile.sql"}, "", "", false},
+		{azuread.ActiveDirectoryDefault, []string{""}, "someuser", "", false},
+		{azuread.ActiveDirectoryDefault, []string{"testdata/someFile.sql"}, "someuser", "", false},
+		{azuread.ActiveDirectoryInteractive, []string{""}, "someuser", "", false},
+		{azuread.ActiveDirectoryInteractive, []string{"testdata/someFile.sql"}, "someuser", "", false},
+		{azuread.ActiveDirectoryManagedIdentity, []string{""}, "someuser", "", false},
+		{azuread.ActiveDirectoryManagedIdentity, []string{"testdata/someFile.sql"}, "someuser", "", false},
+	}
+
+	for _, testcase := range tests {
+		t.Log(testcase.authenticationMethod, testcase.inputFile, testcase.username, testcase.pwd, testcase.expectedResult)
+		args := newArguments()
+		args.DisableCmdAndWarn = true
+		args.InputFile = testcase.inputFile
+		args.UserName = testcase.username
+		vars := sqlcmd.InitializeVariables(!args.DisableCmdAndWarn)
+		setVars(vars, &args)
+		var connectConfig sqlcmd.ConnectSettings
+		setConnect(&connectConfig, &args, vars)
+		connectConfig.AuthenticationMethod = testcase.authenticationMethod
+		connectConfig.Password = testcase.pwd
+		assert.Equal(t, testcase.expectedResult, isConsoleInitializationRequired(&connectConfig, &args), "Unexpected test result encountered for console initialization")
+		assert.Equal(t, testcase.expectedResult, connectConfig.RequiresPassword() && connectConfig.Password == "", "Unexpected test result encountered for password prompt conditions")
+	}
 }
 
 // Assuming public Azure, use AAD when SQLCMDUSER environment variable is not set

--- a/cmd/sqlcmd/main_test.go
+++ b/cmd/sqlcmd/main_test.go
@@ -354,7 +354,7 @@ func TestPasswordPrompt(t *testing.T) {
 	assert.NoError(t, err, "run")
 	assert.Equal(t, 0, exitCode, "exitCode")
 
-	args.UserName = "someuser"
+	args.UserName = "invalidUser"
 	os.Setenv("SQLCMDPASSWORD", "")
 	vars = sqlcmd.InitializeVariables(true)
 	setVars(vars, &args)

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -330,7 +330,7 @@ func connectCommand(s *Sqlcmd, args []string, line uint) error {
 		return InvalidCommandError("CONNECT", line)
 	}
 
-	connect := s.Connect
+	connect := *s.Connect
 	connect.UserName = arguments.Username
 	connect.Password = arguments.Password
 	connect.ServerName = arguments.Server
@@ -339,7 +339,7 @@ func connectCommand(s *Sqlcmd, args []string, line uint) error {
 	}
 	connect.AuthenticationMethod = arguments.AuthenticationMethod
 	// If no user name is provided we switch to integrated auth
-	_ = s.ConnectDb(connect, s.lineIo == nil)
+	_ = s.ConnectDb(&connect, s.lineIo == nil)
 	// ConnectDb prints connection errors already, and failure to connect is not fatal even with -b option
 	return nil
 }

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -339,7 +339,7 @@ func connectCommand(s *Sqlcmd, args []string, line uint) error {
 	}
 	connect.AuthenticationMethod = arguments.AuthenticationMethod
 	// If no user name is provided we switch to integrated auth
-	_ = s.ConnectDb(&connect, s.lineIo == nil)
+	_ = s.ConnectDb(connect, s.lineIo == nil)
 	// ConnectDb prints connection errors already, and failure to connect is not fatal even with -b option
 	return nil
 }

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -167,7 +167,7 @@ func TestConnectCommand(t *testing.T) {
 	err := connectCommand(s, []string{"someserver -U someuser"}, 1)
 	assert.NoError(t, err, "connectCommand with valid arguments doesn't return an error on connect failure")
 	assert.True(t, prompted, "connectCommand with user name and no password should prompt for password")
-	assert.NotEqual(t, "someserver", s.Connect.ServerName, "On error, sqlCmd.Connect does not copy inputs")
+	assert.Equal(t, "someserver", s.Connect.ServerName, "servername should match with the input parameter")
 
 	err = connectCommand(s, []string{}, 2)
 	assert.EqualError(t, err, InvalidCommandError("CONNECT", 2).Error(), ":Connect with no arguments should return an error")

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -167,7 +167,7 @@ func TestConnectCommand(t *testing.T) {
 	err := connectCommand(s, []string{"someserver -U someuser"}, 1)
 	assert.NoError(t, err, "connectCommand with valid arguments doesn't return an error on connect failure")
 	assert.True(t, prompted, "connectCommand with user name and no password should prompt for password")
-	assert.Equal(t, "someserver", s.Connect.ServerName, "servername should match with the input parameter")
+	assert.NotEqual(t, "someserver", s.Connect.ServerName, "On connection failure, sqlCmd.Connect does not copy inputs")
 
 	err = connectCommand(s, []string{}, 2)
 	assert.EqualError(t, err, InvalidCommandError("CONNECT", 2).Error(), ":Connect with no arguments should return an error")

--- a/pkg/sqlcmd/connect.go
+++ b/pkg/sqlcmd/connect.go
@@ -64,7 +64,7 @@ func (connect ConnectSettings) sqlAuthentication() bool {
 		(!connect.UseTrustedConnection && connect.authenticationMethod() == NotSpecified && connect.UserName != "")
 }
 
-func (connect ConnectSettings) requiresPassword() bool {
+func (connect ConnectSettings) RequiresPassword() bool {
 	requiresPassword := connect.sqlAuthentication()
 	if !requiresPassword {
 		switch connect.authenticationMethod() {

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -218,7 +218,7 @@ func (s *Sqlcmd) ConnectDb(connect *ConnectSettings, nopw bool) error {
 
 	var connector driver.Connector
 	useAad := !connect.sqlAuthentication() && !connect.integratedAuthentication()
-	if connect.requiresPassword() && !nopw && connect.Password == "" {
+	if connect.RequiresPassword() && !nopw && connect.Password == "" {
 		var err error
 		if connect.Password, err = s.promptPassword(); err != nil {
 			return err

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -62,7 +62,7 @@ type Sqlcmd struct {
 	batch            *Batch
 	// Exitcode is returned to the operating system when the process exits
 	Exitcode int
-	Connect  ConnectSettings
+	Connect  *ConnectSettings
 	vars     *Variables
 	Format   Formatter
 	Query    string
@@ -79,6 +79,7 @@ func New(l Console, workingDirectory string, vars *Variables) *Sqlcmd {
 		workingDirectory: workingDirectory,
 		vars:             vars,
 		Cmd:              newCommands(),
+		Connect:          &ConnectSettings{},
 	}
 	s.batch = NewBatch(s.scanNext, s.Cmd)
 	mssql.SetContextLogger(s)
@@ -213,7 +214,7 @@ func (s *Sqlcmd) SetError(e io.WriteCloser) {
 func (s *Sqlcmd) ConnectDb(connect *ConnectSettings, nopw bool) error {
 	newConnection := connect != nil
 	if connect == nil {
-		connect = &s.Connect
+		connect = s.Connect
 	}
 
 	var connector driver.Connector
@@ -259,7 +260,7 @@ func (s *Sqlcmd) ConnectDb(connect *ConnectSettings, nopw bool) error {
 		s.vars.Set(SQLCMDUSER, u.Username)
 	}
 	if newConnection {
-		s.Connect = *connect
+		s.Connect = connect
 	}
 	if s.batch != nil {
 		s.batch.batchline = 1

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -366,10 +366,10 @@ func TestPromptForPasswordPositive(t *testing.T) {
 	v := InitializeVariables(true)
 	s := New(console, "", v)
 	// attempt without password prompt
-	err := s.ConnectDb(&c, true)
+	err := s.ConnectDb(c, true)
 	assert.False(t, prompted, "ConnectDb with nopw=true should not prompt for password")
 	assert.Error(t, err, "ConnectDb with nopw==true and no password provided")
-	err = s.ConnectDb(&c, false)
+	err = s.ConnectDb(c, false)
 	assert.True(t, prompted, "ConnectDb with !nopw should prompt for password")
 	assert.NoError(t, err, "ConnectDb with !nopw and valid password returned from prompt")
 	if s.Connect.Password != password {
@@ -505,7 +505,7 @@ func canTestAzureAuth() bool {
 	return strings.Contains(server, ".database.windows.net") && userName == ""
 }
 
-func newConnect(t testing.TB) ConnectSettings {
+func newConnect(t testing.TB) *ConnectSettings {
 	t.Helper()
 	connect := ConnectSettings{
 		UserName:   os.Getenv(SQLCMDUSER),
@@ -517,5 +517,5 @@ func newConnect(t testing.TB) ConnectSettings {
 		t.Log("Using ActiveDirectoryDefault")
 		connect.AuthenticationMethod = azuread.ActiveDirectoryDefault
 	}
-	return connect
+	return &connect
 }


### PR DESCRIPTION
In absence of console or when console reference line is set
to nil, noPwd is set to true which disables password prompt
and when console is not initialized, password cannot be read
from user. This is why when -i is specified, console is not
initialized and we do not see password prompt.
This commit initializes console even if -U is specified so
that password can be read interactively from user.
Resolves #115 

Validation:
```
go-sqlcmd>.\sqlcmd.exe -i test.sql -U sa
Password:



------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Microsoft SQL Server 2012 (SP4-GDR) (KB4583465) - 11.0.7507.2 (X64)
        Nov  1 2020 00:48:37
        Copyright (c) Microsoft Corporation
        Enterprise Edition: Core-based Licensing (64-bit) on Windows NT 6.3 <X64> (Build 9600: ) (Hypervisor)


(1 row affected)
```