### PR TITLE
Distinguish non-error output from error output

### DIFF
--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -85,6 +85,8 @@ func New(l Console, workingDirectory string, vars *Variables) *Sqlcmd {
 	s.PrintError = func(msg string, severity uint8) bool {
 		return false
 	}
+	s.SetOutput(os.Stdout)
+	s.SetError(os.Stderr)
 	return s
 }
 
@@ -133,7 +135,11 @@ func (s *Sqlcmd) Run(once bool, processAll bool) error {
 				args = make([]string, 0)
 				once = true
 			} else {
-				_, _ = s.GetOutput().Write([]byte(err.Error() + SqlcmdEol))
+				if iactive {
+					_, _ = s.GetOutput().Write([]byte(err.Error() + SqlcmdEol))
+				} else {
+					_, _ = s.GetError().Write([]byte(err.Error() + SqlcmdEol))
+				}
 			}
 		}
 		if cmd != nil {
@@ -143,7 +149,11 @@ func (s *Sqlcmd) Run(once bool, processAll bool) error {
 				break
 			}
 			if err != nil {
-				_, _ = s.GetOutput().Write([]byte(err.Error() + SqlcmdEol))
+				if iactive {
+					_, _ = s.GetOutput().Write([]byte(err.Error() + SqlcmdEol))
+				} else {
+					_, _ = s.GetError().Write([]byte(err.Error() + SqlcmdEol))
+				}
 				lastError = err
 			}
 		}

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -109,6 +109,28 @@ func TestSqlCmdQueryAndExit(t *testing.T) {
 	}
 }
 
+func TestSqlCmdOutputAndError(t *testing.T) {
+	s, outfile, errfile := setupSqlcmdWithFileErrorOutput(t)
+	defer os.Remove(outfile.Name())
+	defer os.Remove(errfile.Name())
+	s.Query = "select $(X"
+	err := s.Run(true, false)
+	if assert.NoError(t, err, "s.Run(once = true)") {
+		bytes, err := os.ReadFile(errfile.Name())
+		if assert.NoError(t, err, "os.ReadFile") {
+			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 1."+SqlcmdEol, string(bytes), "Incorrect output from Run")
+		}
+	}
+	s.Query = "select '1'"
+	err = s.Run(true, false)
+	if assert.NoError(t, err, "s.Run(once = true)") {
+		bytes, err := os.ReadFile(outfile.Name())
+		if assert.NoError(t, err, "os.ReadFile") {
+			assert.Equal(t, "1"+SqlcmdEol+SqlcmdEol+"(1 row affected)"+SqlcmdEol, string(bytes), "Incorrect output from Run")
+		}
+	}
+}
+
 // Simulate :r command
 func TestIncludeFileNoExecutions(t *testing.T) {
 	s, file := setupSqlcmdWithFileOutput(t)
@@ -475,6 +497,7 @@ func setupSqlCmdWithMemoryOutput(t testing.TB) (*Sqlcmd, *memoryBuffer) {
 	s.Format = NewSQLCmdDefaultFormatter(true)
 	buf := &memoryBuffer{buf: new(bytes.Buffer)}
 	s.SetOutput(buf)
+	s.SetError(buf)
 	err := s.ConnectDb(nil, true)
 	assert.NoError(t, err, "s.ConnectDB")
 	return s, buf
@@ -490,12 +513,35 @@ func setupSqlcmdWithFileOutput(t testing.TB) (*Sqlcmd, *os.File) {
 	file, err := os.CreateTemp("", "sqlcmdout")
 	assert.NoError(t, err, "os.CreateTemp")
 	s.SetOutput(file)
+	s.SetError(file)
 	err = s.ConnectDb(nil, true)
 	if err != nil {
 		os.Remove(file.Name())
 	}
 	assert.NoError(t, err, "s.ConnectDB")
 	return s, file
+}
+
+func setupSqlcmdWithFileErrorOutput(t testing.TB) (*Sqlcmd, *os.File, *os.File) {
+	t.Helper()
+	v := InitializeVariables(true)
+	v.Set(SQLCMDMAXVARTYPEWIDTH, "0")
+	s := New(nil, "", v)
+	s.Connect = newConnect(t)
+	s.Format = NewSQLCmdDefaultFormatter(true)
+	outfile, err := os.CreateTemp("", "sqlcmdout")
+	assert.NoError(t, err, "os.CreateTemp")
+	errfile, err := os.CreateTemp("", "sqlcmderr")
+	assert.NoError(t, err, "os.CreateTemp")
+	s.SetOutput(outfile)
+	s.SetError(errfile)
+	err = s.ConnectDb(nil, true)
+	if err != nil {
+		os.Remove(outfile.Name())
+		os.Remove(errfile.Name())
+	}
+	assert.NoError(t, err, "s.ConnectDB")
+	return s, outfile, errfile
 }
 
 // Assuming public Azure, use AAD when SQLCMDUSER environment variable is not set


### PR DESCRIPTION
In certain cases such as non-interactive mode it was observed
that error messages meant for error stream were captured under
output stream. This is not desirable if the user only wants to
retrieve the error messages. This commit aligns the go-sqlcmd
behaviour with ODBC sqlcmd where error messages are captured
in the appropriate error stream.
Resolves #105 

Validation:
```
go-sqlcmd>type test.sql
:r missing.sql
go
C:\Users\apdeshmukh\git\go-sqlcmd>type test.sql
:r missing.sql
go
select @@version
go
go-sqlcmd>.\sqlcmd.exe -i test.sql >stdout.txt 2>stderr.txt

go-sqlcmd>type stdout.txt


------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Microsoft SQL Server 2019 (RTM-GDR) (KB5014356) - 15.0.2095.3 (X64)
        Apr 29 2022 18:00:13
        Copyright (C) 2019 Microsoft Corporation
        Developer Edition (64-bit) on Windows 10 Enterprise 10.0 <X64> (Build 22000: ) (Hypervisor)


(1 row affected)

go-sqlcmd>type stderr.txt
Sqlcmd: Error:  Error occurred while opening or operating on file missing.sql (Reason: open missing.sql: The system cannot find the file specified.).

```