### PR TITLE
remove branch filter for build

### DIFF
--- a/build/azure-pipelines/build-product.yml
+++ b/build/azure-pipelines/build-product.yml
@@ -2,9 +2,6 @@ trigger:
   tags:
     include:
       - v*
-  branches:
-    include:
-      - main
 
 pr: none
 


### PR DESCRIPTION
We don't want to trigger a product build for every merge to main. I misunderstood how the trigger works; the tag filter is 'or' not 'and'.