### PR TITLE
block sys commands on -X

### DIFF
--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -230,6 +230,10 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	s := sqlcmd.New(line, wd, vars)
 	s.UnicodeOutputFile = args.UnicodeOutputFile
 
+	if args.DisableCmdAndWarn {
+		s.Cmd.DisableSysCommands(false)
+	}
+
 	if args.BatchTerminator != "GO" {
 		err = s.Cmd.SetBatchTerminator(args.BatchTerminator)
 		if err != nil {

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -116,7 +116,7 @@ func (c Commands) matchCommand(line string) (*Command, []string) {
 }
 
 func warnDisabled(s *Sqlcmd, args []string, line uint) error {
-	s.GetError().Write([]byte(ErrCommandsDisabled.Error() + SqlcmdEol))
+	_, _ = s.GetError().Write([]byte(ErrCommandsDisabled.Error() + SqlcmdEol))
 	return nil
 }
 

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -32,6 +32,8 @@ var (
 	ErrNeedPassword = errors.New("need password")
 	// ErrCtrlC indicates execution was ended by ctrl-c or ctrl-break
 	ErrCtrlC = errors.New(WarningPrefix + "The last operation was terminated because the user pressed CTRL+C")
+	// ErrCommandsDisabled indicates system commands and startup script are disabled
+	ErrCommandsDisabled = errors.New(ErrorPrefix + "ED and !!<command> commands, startup script, and environment variables are disabled.")
 )
 
 const maxLineBuffer = 2 * 1024 * 1024 // 2Mb


### PR DESCRIPTION
I can't quite figure out how to make `-X [1]` work with Kong, so for now I'm staying with `-X`  and warning when a sys command used.