### PR TITLE
Redirect sqlcmd errors to err stream

### DIFF
--- a/cmd/sqlcmd/main.go
+++ b/cmd/sqlcmd/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -259,7 +260,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 		if args.ErrorsToStderr >= 0 {
 			s.PrintError = func(msg string, severity uint8) bool {
 				if severity >= stderrSeverity {
-					_, _ = os.Stderr.Write([]byte(msg + sqlcmd.SqlcmdEol))
+					s.WriteError(os.Stderr, errors.New(msg+sqlcmd.SqlcmdEol))
 					return true
 				}
 				return false
@@ -285,7 +286,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	} else {
 		for f := range args.InputFile {
 			if err = s.IncludeFile(args.InputFile[f], true); err != nil {
-				_, _ = os.Stderr.Write([]byte(err.Error() + sqlcmd.SqlcmdEol))
+				s.WriteError(s.GetError(), err)
 				s.Exitcode = 1
 				break
 			}

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -116,12 +116,12 @@ func (c Commands) matchCommand(line string) (*Command, []string) {
 }
 
 func warnDisabled(s *Sqlcmd, args []string, line uint) error {
-	_, _ = s.GetError().Write([]byte(ErrCommandsDisabled.Error() + SqlcmdEol))
+	s.WriteError(s.GetError(), ErrCommandsDisabled)
 	return nil
 }
 
 func errorDisabled(s *Sqlcmd, args []string, line uint) error {
-	_, _ = s.GetError().Write([]byte(ErrCommandsDisabled.Error() + SqlcmdEol))
+	s.WriteError(s.GetError(), ErrCommandsDisabled)
 	s.Exitcode = 1
 	return ErrExitRequested
 }
@@ -433,7 +433,7 @@ func resolveArgumentVariables(s *Sqlcmd, arg []rune, failOnUnresolved bool) (str
 					if failOnUnresolved {
 						return "", UndefinedVariable(varName)
 					}
-					_, _ = s.GetError().Write([]byte(UndefinedVariable(varName).Error() + SqlcmdEol))
+					s.WriteError(s.GetError(), UndefinedVariable(varName))
 					if b != nil {
 						b.WriteString(string(arg[i : vl+1]))
 					}

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -462,6 +462,44 @@ func TestQueryServerPropertyReturnsColumnName(t *testing.T) {
 	}
 }
 
+func TestSqlCmdOutputAndError(t *testing.T) {
+	s, outfile, errfile := setupSqlcmdWithFileErrorOutput(t)
+	defer os.Remove(outfile.Name())
+	defer os.Remove(errfile.Name())
+	s.Query = "select $(X"
+	err := s.Run(true, false)
+	if assert.NoError(t, err, "s.Run(once = true)") {
+		bytes, err := os.ReadFile(errfile.Name())
+		if assert.NoError(t, err, "os.ReadFile") {
+			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 1."+SqlcmdEol, string(bytes), "Expected syntax error not received for query execution")
+		}
+	}
+	s.Query = "select '1'"
+	err = s.Run(true, false)
+	if assert.NoError(t, err, "s.Run(once = true)") {
+		bytes, err := os.ReadFile(outfile.Name())
+		if assert.NoError(t, err, "os.ReadFile") {
+			assert.Equal(t, "1"+SqlcmdEol+SqlcmdEol+"(1 row affected)"+SqlcmdEol, string(bytes), "Unexpected output for query execution")
+		}
+	}
+
+	s, outfile, errfile = setupSqlcmdWithFileErrorOutput(t)
+	defer os.Remove(outfile.Name())
+	defer os.Remove(errfile.Name())
+	dataPath := "testdata" + string(os.PathSeparator)
+	err = s.IncludeFile(dataPath+"testerrorredirection.sql", false)
+	if assert.NoError(t, err, "IncludeFile testerrorredirection.sql false") {
+		bytes, err := os.ReadFile(outfile.Name())
+		if assert.NoError(t, err, "os.ReadFile outfile") {
+			assert.Equal(t, "1"+SqlcmdEol+SqlcmdEol+"(1 row affected)"+SqlcmdEol, string(bytes), "Unexpected output for sql file execution in outfile")
+		}
+		bytes, err = os.ReadFile(errfile.Name())
+		if assert.NoError(t, err, "os.ReadFile errfile") {
+			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 3."+SqlcmdEol, string(bytes), "Expected syntax error not found in errfile")
+		}
+	}
+}
+
 // runSqlCmd uses lines as input for sqlcmd instead of relying on file or console input
 func runSqlCmd(t testing.TB, s *Sqlcmd, lines []string) error {
 	t.Helper()
@@ -507,6 +545,40 @@ func setupSqlcmdWithFileOutput(t testing.TB) (*Sqlcmd, *os.File) {
 	}
 	assert.NoError(t, err, "s.ConnectDB")
 	return s, file
+}
+
+func setupSqlcmdWithFileErrorOutput(t testing.TB) (*Sqlcmd, *os.File, *os.File) {
+	t.Helper()
+	v := InitializeVariables(true)
+	v.Set(SQLCMDMAXVARTYPEWIDTH, "0")
+	s := New(nil, "", v)
+	s.Connect = newConnect(t)
+	s.Format = NewSQLCmdDefaultFormatter(true)
+	outfile, err := os.CreateTemp("", "sqlcmdout")
+	assert.NoError(t, err, "os.CreateTemp")
+	errfile, err := os.CreateTemp("", "sqlcmderr")
+	assert.NoError(t, err, "os.CreateTemp")
+	s.SetOutput(outfile)
+	s.SetError(errfile)
+	err = s.ConnectDb(nil, true)
+	if err != nil {
+		os.Remove(outfile.Name())
+		os.Remove(errfile.Name())
+	}
+	assert.NoError(t, err, "s.ConnectDB")
+	return s, outfile, errfile
+}
+
+func setupSqlcmd(t testing.TB) *Sqlcmd {
+	t.Helper()
+	v := InitializeVariables(true)
+	v.Set(SQLCMDMAXVARTYPEWIDTH, "0")
+	s := New(nil, "", v)
+	s.Connect = newConnect(t)
+	s.Format = NewSQLCmdDefaultFormatter(true)
+	err := s.ConnectDb(nil, true)
+	assert.NoError(t, err, "s.ConnectDB")
+	return s
 }
 
 // Assuming public Azure, use AAD when SQLCMDUSER environment variable is not set


### PR DESCRIPTION
By default sqlcmd uses stdout as the default stream for output and errors.
As a result when the stderr is redirected externally to file, the sqlcmd errors are missed.
This commit logs all the sqlcmd errors to the stderr of OS in case default output
stream is stdout and stderr for sqlcmd is not set.