### PR TITLE
Implement `:ED`

### DIFF
--- a/pkg/sqlcmd/batch.go
+++ b/pkg/sqlcmd/batch.go
@@ -147,7 +147,7 @@ parse:
 	if err == nil {
 		i = min(i, b.rawlen)
 		empty := isEmptyLine(b.raw, 0, i)
-		appendLine := b.quote != 0 || b.comment || !empty
+		appendLine := true
 		if !b.comment && command != nil && empty {
 			appendLine = false
 		}

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -287,3 +287,14 @@ func TestDisableSysCommandBlocksExec(t *testing.T) {
 		assert.Equal(t, 1, s.Exitcode, "ExitCode after error")
 	}
 }
+
+func TestEditCommand(t *testing.T) {
+	s, buf := setupSqlCmdWithMemoryOutput(t)
+	defer buf.Close()
+	s.vars.Set(SQLCMDEDITOR, "echo select 'test' > ")
+	c := []string{"set nocount on", "go", "select 100", ":ed", "go"}
+	err := runSqlCmd(t, s, c)
+	if assert.NoError(t, err, ":ed should not raise error") {
+		assert.Equal(t, "1> select 'test' " + SqlcmdEol + "test"+SqlcmdEol+SqlcmdEol, buf.buf.String(), "Incorrect output from query after :ed command")
+	}
+}

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -291,10 +291,10 @@ func TestDisableSysCommandBlocksExec(t *testing.T) {
 func TestEditCommand(t *testing.T) {
 	s, buf := setupSqlCmdWithMemoryOutput(t)
 	defer buf.Close()
-	s.vars.Set(SQLCMDEDITOR, "echo select 5000 > ")
+	s.vars.Set(SQLCMDEDITOR, "echo select 5000> ")
 	c := []string{"set nocount on", "go", "select 100", ":ed", "go"}
 	err := runSqlCmd(t, s, c)
 	if assert.NoError(t, err, ":ed should not raise error") {
-		assert.Equal(t, "1> select 5000 "+SqlcmdEol+"5000"+SqlcmdEol+SqlcmdEol, buf.buf.String(), "Incorrect output from query after :ed command")
+		assert.Equal(t, "1> select 5000"+SqlcmdEol+"5000"+SqlcmdEol+SqlcmdEol, buf.buf.String(), "Incorrect output from query after :ed command")
 	}
 }

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -291,10 +291,10 @@ func TestDisableSysCommandBlocksExec(t *testing.T) {
 func TestEditCommand(t *testing.T) {
 	s, buf := setupSqlCmdWithMemoryOutput(t)
 	defer buf.Close()
-	s.vars.Set(SQLCMDEDITOR, "echo select 'test' > ")
+	s.vars.Set(SQLCMDEDITOR, "echo select 5000 > ")
 	c := []string{"set nocount on", "go", "select 100", ":ed", "go"}
 	err := runSqlCmd(t, s, c)
 	if assert.NoError(t, err, ":ed should not raise error") {
-		assert.Equal(t, "1> select 'test' " + SqlcmdEol + "test"+SqlcmdEol+SqlcmdEol, buf.buf.String(), "Incorrect output from query after :ed command")
+		assert.Equal(t, "1> select 5000 "+SqlcmdEol+"5000"+SqlcmdEol+SqlcmdEol, buf.buf.String(), "Incorrect output from query after :ed command")
 	}
 }

--- a/pkg/sqlcmd/exec_darwin.go
+++ b/pkg/sqlcmd/exec_darwin.go
@@ -14,3 +14,5 @@ func comSpec() string {
 	// /bin/sh will be a link to the shell
 	return `/bin/sh`
 }
+
+const defaultEditor = "vi"

--- a/pkg/sqlcmd/exec_linux.go
+++ b/pkg/sqlcmd/exec_linux.go
@@ -14,3 +14,5 @@ func comSpec() string {
 	// /bin/sh will be a link to the shell
 	return `/bin/sh`
 }
+
+const defaultEditor = "vi"

--- a/pkg/sqlcmd/exec_windows.go
+++ b/pkg/sqlcmd/exec_windows.go
@@ -23,3 +23,5 @@ func comSpec() string {
 func comArgs(args string) string {
 	return `/c ` + args
 }
+
+const defaultEditor = "notepad.exe"

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -62,6 +62,7 @@ type Sqlcmd struct {
 	out              io.WriteCloser
 	err              io.WriteCloser
 	batch            *Batch
+	echoFileLines    bool
 	// Exitcode is returned to the operating system when the process exits
 	Exitcode int
 	Connect  *ConnectSettings
@@ -297,6 +298,7 @@ func (s *Sqlcmd) IncludeFile(path string, processAll bool) error {
 	buf := make([]byte, maxLineBuffer)
 	scanner.Buffer(buf, maxLineBuffer)
 	curLine := s.batch.read
+	echoFileLines := s.echoFileLines
 	s.batch.read = func() (string, error) {
 		if !scanner.Scan() {
 			err := scanner.Err()
@@ -305,14 +307,20 @@ func (s *Sqlcmd) IncludeFile(path string, processAll bool) error {
 			}
 			return "", err
 		}
-		return scanner.Text(), nil
+		t := scanner.Text()
+		if echoFileLines {
+			_, _ = s.GetOutput().Write([]byte(s.Prompt() + t + SqlcmdEol))
+		}
+		return t, nil
 	}
 	err = s.Run(false, processAll)
 	s.batch.read = curLine
-	if s.batch.State() == "=" {
-		s.batch.batchline = 1
-	} else {
-		s.batch.batchline = b + 1
+	if !s.echoFileLines {
+		if s.batch.State() == "=" {
+			s.batch.batchline = 1
+		} else {
+			s.batch.batchline = b + 1
+		}
 	}
 	return err
 }

--- a/pkg/sqlcmd/variables.go
+++ b/pkg/sqlcmd/variables.go
@@ -179,6 +179,11 @@ func (v Variables) Format() string {
 	return "horizontal"
 }
 
+// TextEditor is the query editor application launched by the :ED command
+func (v Variables) TextEditor() string {
+	return v[SQLCMDEDITOR]
+}
+
 func mustValue(val string) int64 {
 	var n int64
 	_, err := fmt.Sscanf(val, "%d", &n)
@@ -193,7 +198,7 @@ func mustValue(val string) int64 {
 var defaultVariables = Variables{
 	SQLCMDCOLSEP:            " ",
 	SQLCMDCOLWIDTH:          "0",
-	SQLCMDEDITOR:            "edit.com",
+	SQLCMDEDITOR:            defaultEditor,
 	SQLCMDERRORLEVEL:        "0",
 	SQLCMDHEADERS:           "0",
 	SQLCMDLOGINTIMEOUT:      "30",


### PR DESCRIPTION
`:ed` is a system command

```
e:\git\go-sqlcmd\cmd\sqlcmd>sqlcmd -S davidshi-2019 -X
1> ed
Sqlcmd: Error: ED and !!<command> commands, startup script, and environment variables are disabled.
```

Also, preserve blank lines from input.

Pre-fix:
```
e:\git\go-sqlcmd\cmd\sqlcmd>.\sqlcmd
1> select 100
2>
2>
2>
2>
2> select 200
3> :list
select 100
select 200
3>
```


ODBC:
```
e:\git\go-sqlcmd\cmd\sqlcmd>"C:\Program Files\Microsoft SQL Server\110\Tools\Binn\SQLCMD.EXE"
1> select 100
2>
3>
4>
5>
6> select 200
7> :list
select 100




select 200
7>
```

With Fix:

```
e:\git\go-sqlcmd\cmd\sqlcmd>.\sqlcmd
1> select 100
2>
3>
4>
5>
6> select 200
7> :list
select 100




select 200
7>
```