### PR TITLE
Refactor and separate sqlcmd errors from server erros

### DIFF
--- a/pkg/sqlcmd/batch_test.go
+++ b/pkg/sqlcmd/batch_test.go
@@ -90,7 +90,7 @@ func TestBatchNextErrOnInvalidVariable(t *testing.T) {
 		cmd, _, err := b.Next()
 		assert.Nil(t, cmd, "cmd for "+test)
 		assert.Equal(t, uint(1), b.linecount, "linecount should increment on a variable syntax error")
-		assert.EqualErrorf(t, err, "Sqlcmd: Error: Syntax error at line 1.", "expected err for %s", test)
+		assert.EqualErrorf(t, err, "Sqlcmd: Error: Syntax error at line 1", "expected err for %s", test)
 	}
 }
 
@@ -165,7 +165,7 @@ func TestReadStringMalformedVariable(t *testing.T) {
 		r := []rune(test)
 		_, ok, err := b.readString(r, 1, len(test), '\'', 10)
 		assert.Falsef(t, ok, "ok for %s", test)
-		assert.EqualErrorf(t, err, "Sqlcmd: Error: Syntax error at line 10.", "expected err for %s", test)
+		assert.EqualErrorf(t, err, "Sqlcmd: Error: Syntax error at line 10", "expected err for %s", test)
 	}
 }
 

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -33,7 +33,9 @@ var (
 	// ErrCtrlC indicates execution was ended by ctrl-c or ctrl-break
 	ErrCtrlC = errors.New(WarningPrefix + "The last operation was terminated because the user pressed CTRL+C")
 	// ErrCommandsDisabled indicates system commands and startup script are disabled
-	ErrCommandsDisabled = errors.New(ErrorPrefix + "ED and !!<command> commands, startup script, and environment variables are disabled.")
+	ErrCommandsDisabled = &CommonSqlcmdErr{
+		message: ErrCmdDisabled,
+	}
 )
 
 const maxLineBuffer = 2 * 1024 * 1024 // 2Mb
@@ -215,11 +217,11 @@ func (s *Sqlcmd) SetError(e io.WriteCloser) {
 
 // WriteError writes the error on specified stream
 func (s *Sqlcmd) WriteError(stream io.Writer, err error) {
-	if strings.HasPrefix(err.Error(), ErrorPrefix) {
+	if serr, ok := err.(SqlcmdError); ok {
 		if s.GetError() != os.Stdout {
-			_, _ = s.GetError().Write([]byte(err.Error() + SqlcmdEol))
+			_, _ = s.GetError().Write([]byte(serr.Error() + SqlcmdEol))
 		} else {
-			_, _ = os.Stderr.Write([]byte(err.Error() + SqlcmdEol))
+			_, _ = os.Stderr.Write([]byte(serr.Error() + SqlcmdEol))
 		}
 	} else {
 		_, _ = stream.Write([]byte(err.Error() + SqlcmdEol))

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -104,7 +104,7 @@ func TestSqlCmdQueryAndExit(t *testing.T) {
 		s.SetOutput(nil)
 		bytes, err := os.ReadFile(file.Name())
 		if assert.NoError(t, err, "os.ReadFile") {
-			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 1."+SqlcmdEol, string(bytes), "Incorrect output from Run")
+			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 1"+SqlcmdEol, string(bytes), "Incorrect output from Run")
 		}
 	}
 }
@@ -471,7 +471,7 @@ func TestSqlCmdOutputAndError(t *testing.T) {
 	if assert.NoError(t, err, "s.Run(once = true)") {
 		bytes, err := os.ReadFile(errfile.Name())
 		if assert.NoError(t, err, "os.ReadFile") {
-			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 1."+SqlcmdEol, string(bytes), "Expected syntax error not received for query execution")
+			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 1"+SqlcmdEol, string(bytes), "Expected syntax error not received for query execution")
 		}
 	}
 	s.Query = "select '1'"
@@ -495,7 +495,7 @@ func TestSqlCmdOutputAndError(t *testing.T) {
 		}
 		bytes, err = os.ReadFile(errfile.Name())
 		if assert.NoError(t, err, "os.ReadFile errfile") {
-			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 3."+SqlcmdEol, string(bytes), "Expected syntax error not found in errfile")
+			assert.Equal(t, "Sqlcmd: Error: Syntax error at line 3"+SqlcmdEol, string(bytes), "Expected syntax error not found in errfile")
 		}
 	}
 }


### PR DESCRIPTION
This commit addresses #144 
A dummy function IsSqlcmdErr() has been added in SqlcmdErr interface 
to distinguish Sqlcmd errors from server errors. 
The only purpose of it is to distinguish SqlcmdErr interface from the 
generic Error interface. From now on all sqlcmd errors should implement
 SqlcmdErr interface to distinguish itself from other errors.