### PR TITLE
Adding Global Flag in Modern CLI

### DIFF
--- a/cmd/modern/root.go
+++ b/cmd/modern/root.go
@@ -17,6 +17,7 @@ type Root struct {
 	configFilename string
 	loggingLevel   int
 	outputType     string
+	inputType      string
 }
 
 // DefineCommand defines the top-level sqlcmd sub-commands.
@@ -112,5 +113,13 @@ func (c *Root) addGlobalFlags() {
 		Name:       "verbosity",
 		Shorthand:  "v",
 		Usage:      "Log level, error=0, warn=1, info=2, debug=3, trace=4",
+	})
+
+	c.AddFlag(cmdparser.FlagOptions{
+		String:        &c.inputType,
+		DefaultString: "yaml",
+		Name:          "InputFile",
+		Shorthand:     "i",
+		Usage:         "output type (yaml, json or xml)",
 	})
 }


### PR DESCRIPTION
In order to migrate all the commands from Kong to Modern CLI,
I have started with one flag here : InputFile.