### PR TITLE
on error ignore precedence over -b

### DIFF
--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -103,9 +103,9 @@ func newCommands() Commands {
 			isSystem: true,
 		},
 		"ONERROR": {
-			regex:    regexp.MustCompile(`(?im)^[\t ]*?:?ONERROR(?:[ \t]+(.*$)|$)`),
-			action:   onerrorCommand,
-			name:     "ONERROR",
+			regex:  regexp.MustCompile(`(?im)^[\t ]*?:?ONERROR(?:[ \t]+(.*$)|$)`),
+			action: onerrorCommand,
+			name:   "ONERROR",
 		},
 	}
 }
@@ -474,6 +474,7 @@ func onerrorCommand(s *Sqlcmd, args []string, line uint) error {
 		s.Connect.ExitOnError = true
 	} else if strings.EqualFold(strings.ToLower(params), "ignore") {
 		s.Connect.IgnoreError = true
+		s.Connect.ExitOnError = false
 	} else {
 		return InvalidCommandError("ON ERROR", line)
 	}

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -243,10 +243,13 @@ func TestOnErrorCommand(t *testing.T) {
 	// -b sets ExitOnError true
 	s.Connect.ExitOnError = true
 	err = runSqlCmd(t, s, []string{":ONERROR ignore", "printtgit N'message'", "SELECT @@versionn", "GO"})
+	// when ignore is set along with -b command , ignore takes precedence and resets ExitOnError
 	assert.Equal(t, false, s.Connect.ExitOnError, "ExitOnError")
 	assert.NoError(t, err, "runSqlCmd")
+	// checking ExitonError with  Exit option
 	err = runSqlCmd(t, s, []string{":ONERROR exit", "printtgit N'message'", "SELECT @@versionn", "GO"})
 	assert.Equal(t, true, s.Connect.ExitOnError, "ExitOnError")
+	assert.NoError(t, err, "runSqlCmd")
 }
 func TestResolveArgumentVariables(t *testing.T) {
 	type argTest struct {

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -240,6 +240,13 @@ func TestOnErrorCommand(t *testing.T) {
 	err = runSqlCmd(t, s, []string{":ONERROR exit", "printtgit N'message'", "SELECT @@versionn", "GO"})
 	assert.NoError(t, err, "runSqlCmd")
 	assert.Equal(t, 1, s.Exitcode, "ExitCode")
+	// -b sets ExitOnError true
+	s.Connect.ExitOnError = true
+	err = runSqlCmd(t, s, []string{":ONERROR ignore", "printtgit N'message'", "SELECT @@versionn", "GO"})
+	assert.Equal(t, false, s.Connect.ExitOnError, "ExitOnError")
+	assert.NoError(t, err, "runSqlCmd")
+	err = runSqlCmd(t, s, []string{":ONERROR exit", "printtgit N'message'", "SELECT @@versionn", "GO"})
+	assert.Equal(t, true, s.Connect.ExitOnError, "ExitOnError")
 }
 func TestResolveArgumentVariables(t *testing.T) {
 	type argTest struct {


### PR DESCRIPTION
https://github.com/microsoft/go-sqlcmd/issues/179
When a user specifies following command :
"sqlcmd on-error.sql -b"

In on-error.sql :

:ONERROR ignore

select @@versionn

GO

select @@version

GO
Actual Output : It is exiting with error code.
Expected Output : It should run with only printing error message