### PR TITLE
Check sub-command for modernCLI only if specified

### DIFF
--- a/cmd/modern/main.go
+++ b/cmd/modern/main.go
@@ -49,7 +49,7 @@ func main() {
 // isFirstArgModernCliSubCommand is TEMPORARY code, to be removed when
 // we remove the Kong based CLI
 func isFirstArgModernCliSubCommand() (isNewCliCommand bool) {
-	if len(os.Args) > 0 {
+	if len(os.Args) > 1 {
 		if rootCmd.IsValidSubCommand(os.Args[1]) {
 			isNewCliCommand = true
 		}


### PR DESCRIPTION
This commit addresses #183.

```
git\go-sqlcmd\cmd\modern>.\sqlcmd.exe
1> select @@version
2> go



------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Microsoft SQL Server 2019 (RTM-GDR) (KB5014356) - 15.0.2095.3 (X64)
        Apr 29 2022 18:00:13
        Copyright (C) 2019 Microsoft Corporation
        Developer Edition (64-bit) on Windows 10 Enterprise 10.0 <X64> (Build 22621: ) (Hypervisor)


(1 row affected)
```