### PR TITLE
Create "Failing Test" for issue 197

### DIFF
--- a/myscript.sh
+++ b/myscript.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Starting SQL Server in background"
+/opt/mssql/bin/sqlservr &
+
+# wait for SQL Server to start up.
+sleep 30s
+
+sqlcmd -i /app/myscript.sql -U SA

--- a/myscript.sh
+++ b/myscript.sh
@@ -6,4 +6,10 @@ echo "Starting SQL Server in background"
 # wait for SQL Server to start up.
 sleep 30s
 
-sqlcmd -i /app/myscript.sql -U SA
+echo "running script with SQLCMD legacy"
+
+/opt/mssql-tools/bin/sqlcmd -i /app/myscript.sql -U SA
+
+echo "running script with SQLCMD GO"
+
+sqlcmd-go -i /app/myscript.sql -U SA

--- a/myscript.sql
+++ b/myscript.sql
@@ -1,0 +1,6 @@
+:setvar SomeVariable "This is my test variable for issue 197"
+GO
+
+print N'$(SomeVariable)'
+
+GO

--- a/sql-server-linux.dockerfile
+++ b/sql-server-linux.dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/mssql/server:2017-latest
+
+RUN wget -q https://github.com/microsoft/go-sqlcmd/releases/download/v0.11.0/sqlcmd-v0.11.0-linux-arm64.tar.bz2 && \
+    tar -xvjf sqlcmd-v0.11.0-linux-arm64.tar.bz2 && \
+    chmod +x ./sqlcmd && \
+    mv ./sqlcmd /usr/bin/sqlcmd && \
+    rm sqlcmd-v0.11.0-linux-arm64.tar.bz2
+
+ENV ACCEPT_EULA=Y
+ENV MSSQL_PID=Developer
+ENV SA_PASSWORD="SomeRandomPassw0rdForContainer"
+ENV SQLCMDPASSWORD=${SA_PASSWORD}
+
+COPY myscript.sql /app/
+COPY myscript.sh /app/
+
+CMD /app/myscript.sh

--- a/sql-server-linux.dockerfile
+++ b/sql-server-linux.dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/mssql/server:2017-latest
 RUN wget -q https://github.com/microsoft/go-sqlcmd/releases/download/v0.11.0/sqlcmd-v0.11.0-linux-arm64.tar.bz2 && \
     tar -xvjf sqlcmd-v0.11.0-linux-arm64.tar.bz2 && \
     chmod +x ./sqlcmd && \
-    mv ./sqlcmd /usr/bin/sqlcmd && \
+    mv ./sqlcmd /usr/bin/sqlcmd-go && \
     rm sqlcmd-v0.11.0-linux-arm64.tar.bz2
 
 ENV ACCEPT_EULA=Y


### PR DESCRIPTION
This PR is not intended to be merged.  It is to provide an executable demonstration of the issue described in #197.  I ran this on Windows 10 on x64 with Docker Desktop installed.

Instructions:
  * Run `docker build -f sql-server-linux.dockerfile .`
  * Run the image based on the build SHA - on my system the command was `docker run 7615266b`

**Expected result:** After 30 seconds (the `sleep` time in the shell script), the script prints:

```
running script with SQLCMD legacy
This is my test variable for issue 197
running script with SQLCMD GO
This is my test variable for issue 197
```

**Actual result:** After 30 seconds, go-sqlcmd produces the following output:

```
running script with SQLCMD legacy
This is my test variable for issue 197
running script with SQLCMD GO
Msg 128, Level 15, State 1, Server 485dab2e6162, Line 2
The name "NThis" is not permitted in this context. Valid expressions are constants, constant expressions, and (in some contexts) variables. Column names are not permitted.
Msg 105, Level 15, State 1, Server 485dab2e6162, Line 2
Unclosed quotation mark after the character string '
'.
```
