### PR TITLE
Remove unused globaloptions var

### DIFF
--- a/cmd/modern/options.go
+++ b/cmd/modern/options.go
@@ -18,5 +18,3 @@ type GlobalOptions struct {
 	Encrypt                string
 	DriverLogLevel         int
 }
-
-var globalOptions = &GlobalOptions{}


### PR DESCRIPTION
Remove unused var, which is being picked up by the GitHub action (but not being picked up by the PR pipelines).  (longer term we need to work out why this happend, why is something getting flaged post merge)