### PR TITLE
Fix ARM64 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ testresults.xml
 # IDE files
 .idea
 
+darwin-amd64/sqlcmd
+darwin-arm64/sqlcmd
+linux-amd64/sqlcmd
+linux-arm64/sqlcmd
+linux-s390x/sqlcmd

--- a/build/arch.txt
+++ b/build/arch.txt
@@ -5,3 +5,4 @@ linux,arm64,sqlcmd
 linux,s390x,sqlcmd
 windows,arm64,sqlcmd.exe
 windows,amd64,sqlcmd.exe
+windows,arm,sqlcmd.exe

--- a/build/arch.txt
+++ b/build/arch.txt
@@ -1,0 +1,7 @@
+darwin,amd64,sqlcmd
+darwin,arm64,sqlcmd
+linux,amd64,sqlcmd
+linux,arm64,sqlcmd
+linux,s390x,sqlcmd
+windows,arm64,sqlcmd.exe
+windows,amd64,sqlcmd.exe

--- a/build/azure-pipelines/build-product.yml
+++ b/build/azure-pipelines/build-product.yml
@@ -50,10 +50,16 @@ stages:
             binaryName: 'sqlcmd'
           windowsArm:
            imageName: 'windows-latest'
-           artifact: WindowsArm64
+           artifact: WindowsArm
            os:
-           arch: arm64
+           arch: arm
            binaryName: 'sqlcmd.exe'
+          windowsArm64:
+            imageName: 'windows-latest'
+            artifact: WindowsArm64
+            os:
+            arch: arm64
+            binaryName: 'sqlcmd.exe' 
           linuxs390x:
             imageName: 'ubuntu-latest'
             artifact: LinuxS390x
@@ -146,6 +152,14 @@ stages:
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-x64.zip'
+
+      - task: ArchiveFiles@2
+        displayName: Zip Windows arm binary
+        inputs:
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm\Sqlcmd.exe'
+          includeRootFolder: false
+          archiveType: 'zip'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm.zip'
 
       - task: ArchiveFiles@2
         displayName: Zip Windows arm64 binary

--- a/build/azure-pipelines/build-product.yml
+++ b/build/azure-pipelines/build-product.yml
@@ -30,6 +30,12 @@ stages:
             os:
             arch:
             binaryName: 'sqlcmd'
+          macArm:
+            imageName: 'macOS-latest'
+            artifact: DarwinArm64
+            os:
+            arch: arm64
+            binaryName: 'sqlcmd'
           windows:
             imageName: 'windows-latest'
             artifact: WindowsAmd64
@@ -42,14 +48,12 @@ stages:
             os:
             arch: arm64
             binaryName: 'sqlcmd'
-          # BUG: https://github.com/microsoft/go-sqlcmd/issues/224
-          # Windows ARM build failing in named pipes code
-          #windowsArm:
-          #  imageName: 'windows-latest'
-          #  artifact: WindowsArm
-          #  os:
-          #  arch: arm
-          #  binaryName: 'sqlcmd.exe'
+          windowsArm:
+           imageName: 'windows-latest'
+           artifact: WindowsArm64
+           os:
+           arch: arm64
+           binaryName: 'sqlcmd.exe'
           linuxs390x:
             imageName: 'ubuntu-latest'
             artifact: LinuxS390x
@@ -143,13 +147,13 @@ stages:
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-x64.zip'
 
-      #- task: ArchiveFiles@2
-      #  displayName: Zip Windows arm binary
-      #  inputs:
-      #    rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm\Sqlcmd.exe'
-      #    includeRootFolder: false
-      #    archiveType: 'zip'
-      #    archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm.zip'
+      - task: ArchiveFiles@2
+        displayName: Zip Windows arm64 binary
+        inputs:
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm64\Sqlcmd.exe'
+          includeRootFolder: false
+          archiveType: 'zip'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm64.zip'
   
       - task: ArchiveFiles@2
         displayName: Tar Linux amd64 binary
@@ -168,6 +172,15 @@ stages:
           archiveType: 'tar'
           tarCompression: 'bz2'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-darwin-x64.tar.bz2'
+
+      - task: ArchiveFiles@2
+        displayName: Tar Darwin Arm binary
+        inputs:
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdDarwinArm64'
+          includeRootFolder: false
+          archiveType: 'tar'
+          tarCompression: 'bz2'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-darwin-arm64.tar.bz2'
 
       - task: ArchiveFiles@2
         displayName: Tar Linux arm64 binary

--- a/build/azure-pipelines/build-product.yml
+++ b/build/azure-pipelines/build-product.yml
@@ -148,7 +148,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Zip Windows amd64 binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsAmd64\Sqlcmd.exe'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsAmd64'
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-x64.zip'
@@ -156,7 +156,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Zip Windows arm binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm\Sqlcmd.exe'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm'
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm.zip'
@@ -164,7 +164,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Zip Windows arm64 binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm64\Sqlcmd.exe'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm64'
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm64.zip'

--- a/build/build.cmd
+++ b/build/build.cmd
@@ -13,4 +13,9 @@ go-licenses report github.com/microsoft/go-sqlcmd/cmd/modern --template build\NO
 copy %~dp0NOTICE.header + %~dp0notice.txt %~dp0..\NOTICE.md
 del %~dp0notice.txt
 
+REM Generates all versions of sqlcmd in platform-specific folder
+setlocal
+
+for /F "tokens=1-3 delims=," %%i in (%~dp0arch.txt) do set GOOS=%%i&set GOARCH=%%j&go build -o %~dp0..\%%i-%%j\%%k -ldflags="-X main.version=%sqlcmdVersion%" %~dp0..\cmd\modern
+
 

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -21,8 +21,6 @@ import (
 	"github.com/golang-sql/sqlexp"
 	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/microsoft/go-mssqldb/msdsn"
-	_ "github.com/microsoft/go-mssqldb/namedpipe"
-	_ "github.com/microsoft/go-mssqldb/sharedmemory"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -538,14 +536,4 @@ func (s *Sqlcmd) handleError(retcode *int, err error) error {
 func (s Sqlcmd) Log(_ context.Context, _ msdsn.Log, msg string) {
 	_, _ = s.GetOutput().Write([]byte("DRIVER:" + msg))
 	_, _ = s.GetOutput().Write([]byte(SqlcmdEol))
-}
-
-func init() {
-	if len(msdsn.ProtocolParsers) == 3 {
-		// reorder the protocol parsers to lpc->np->tcp
-		// ODBC follows this same order.
-		var tcp = msdsn.ProtocolParsers[0]
-		msdsn.ProtocolParsers[0] = msdsn.ProtocolParsers[2]
-		msdsn.ProtocolParsers[2] = tcp
-	}
 }

--- a/pkg/sqlcmd/sqlcmd_windows_amd64.go
+++ b/pkg/sqlcmd/sqlcmd_windows_amd64.go
@@ -1,0 +1,17 @@
+package sqlcmd
+
+import (
+	"github.com/microsoft/go-mssqldb/msdsn"
+	_ "github.com/microsoft/go-mssqldb/namedpipe"
+	_ "github.com/microsoft/go-mssqldb/sharedmemory"
+)
+
+func init() {
+	if len(msdsn.ProtocolParsers) == 3 {
+		// reorder the protocol parsers to lpc->np->tcp
+		// ODBC follows this same order.
+		var tcp = msdsn.ProtocolParsers[0]
+		msdsn.ProtocolParsers[0] = msdsn.ProtocolParsers[2]
+		msdsn.ProtocolParsers[2] = tcp
+	}
+}


### PR DESCRIPTION
Fixes #224 
Fixes #223 
Updates `build\build.cmd` to run all the crossplatform builds to test locally before pushing a PR.
