### PR TITLE
Establish conn to curret-context if no args given

### DIFF
--- a/cmd/modern/main.go
+++ b/cmd/modern/main.go
@@ -60,6 +60,7 @@ func initializeEnvVars() {
 		os.Setenv("SQLCMDSERVER", server)
 		os.Setenv("SQLCMDUSER", username)
 		os.Setenv("SQLCMDPASSWORD", password)
+		outputter.Infof("%vUsing current-context: %s", sqlcmd.SqlcmdEol, config.CurrentContextName())
 	}
 }
 

--- a/cmd/modern/main.go
+++ b/cmd/modern/main.go
@@ -41,11 +41,11 @@ func main() {
 			ErrorHandler:   checkErr,
 			HintHandler:    displayHints})}
 	rootCmd = cmdparser.New[*Root](dependencies)
-	initializeEnvVars()
 	if isFirstArgModernCliSubCommand() {
 		cmdparser.Initialize(initializeCallback)
 		rootCmd.Execute()
 	} else {
+		initializeEnvVars()
 		legacyCmd.Execute(version)
 	}
 }
@@ -55,7 +55,7 @@ func main() {
 // if user provides this info via backward compatibility syntax
 func initializeEnvVars() {
 	initializeCallback()
-	if config.CurrentContextName() != "" && config.IsCurrentContextValid() {
+	if config.CurrentContextName() != "" {
 		server, username, password := config.GetCurrentContextInfo()
 		os.Setenv("SQLCMDSERVER", server)
 		os.Setenv("SQLCMDUSER", username)

--- a/cmd/modern/main.go
+++ b/cmd/modern/main.go
@@ -51,16 +51,23 @@ func main() {
 }
 
 // initializeEnvVars intializes SQLCMDSERVER, SQLCMDUSER and SQLCMDPASSWORD
-// if the currentContext is set. This env variables do not have any effect
-// if user provides this info via backward compatibility syntax
+// if the currentContext is set and if these env vars are not already set.
+// In terms of precedence, command line switches/flags take higher precedence
+// than env variables and env variables take higher precedence over config
+// file info.
 func initializeEnvVars() {
 	initializeCallback()
 	if config.CurrentContextName() != "" {
 		server, username, password := config.GetCurrentContextInfo()
-		os.Setenv("SQLCMDSERVER", server)
-		os.Setenv("SQLCMDUSER", username)
-		os.Setenv("SQLCMDPASSWORD", password)
-		outputter.Infof("%vUsing current-context: %s", sqlcmd.SqlcmdEol, config.CurrentContextName())
+		if os.Getenv("SQLCMDSERVER") == "" {
+			os.Setenv("SQLCMDSERVER", server)
+		}
+		if os.Getenv("SQLCMDUSER") == "" {
+			os.Setenv("SQLCMDUSER", username)
+		}
+		if os.Getenv("SQLCMDPASSWORD") == "" {
+			os.Setenv("SQLCMDPASSWORD", password)
+		}
 	}
 }
 

--- a/cmd/modern/main.go
+++ b/cmd/modern/main.go
@@ -41,11 +41,25 @@ func main() {
 			ErrorHandler:   checkErr,
 			HintHandler:    displayHints})}
 	rootCmd = cmdparser.New[*Root](dependencies)
+	initializeEnvVars()
 	if isFirstArgModernCliSubCommand() {
 		cmdparser.Initialize(initializeCallback)
 		rootCmd.Execute()
 	} else {
 		legacyCmd.Execute(version)
+	}
+}
+
+// initializeEnvVars intializes SQLCMDSERVER, SQLCMDUSER and SQLCMDPASSWORD
+// if the currentContext is set. This env variables do not have any effect
+// if user provides this info via backward compatibility syntax
+func initializeEnvVars() {
+	initializeCallback()
+	if config.CurrentContextName() != "" && config.IsCurrentContextValid() {
+		server, username, password := config.GetCurrentContextInfo()
+		os.Setenv("SQLCMDSERVER", server)
+		os.Setenv("SQLCMDUSER", username)
+		os.Setenv("SQLCMDPASSWORD", password)
 	}
 }
 

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -94,6 +94,47 @@ func CurrentContext() (endpoint Endpoint, user *User) {
 	return
 }
 
+// GetCurrentContextInfo returns endpoint and basic auth info
+// associated with current context
+func GetCurrentContextInfo() (server string, username string, password string) {
+	endpoint, user := CurrentContext()
+	server = fmt.Sprintf("%s,%d", endpoint.Address, endpoint.Port)
+	username = user.BasicAuth.Username
+	if user.AuthenticationType == "basic" {
+		password = decryptCallback(
+			user.BasicAuth.Password,
+			user.BasicAuth.PasswordEncrypted,
+		)
+	}
+	return
+}
+
+// isCurrentContextValid returns true if it has valid information associated
+// such as endpoint and user.
+func IsCurrentContextValid() (isValid bool) {
+	currentContextName := CurrentContextName()
+	endPointFound := false
+	userFound := false
+	for _, c := range config.Contexts {
+		if c.Name == currentContextName {
+			for _, e := range config.Endpoints {
+				if e.Name == c.Endpoint {
+					endPointFound = true
+					break
+				}
+			}
+
+			for _, u := range config.Users {
+				if u.Name == *c.User && u.Name != "" {
+					userFound = true
+					break
+				}
+			}
+		}
+	}
+	return endPointFound && userFound
+}
+
 // DeleteContext removes the context with the given name from the application's
 // configuration. If the context does not exist, the function does nothing. The
 // function also updates the CurrentContext field in the configuration to the

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -75,10 +75,12 @@ func CurrentContext() (endpoint Endpoint, user *User) {
 				}
 			}
 
-			for _, u := range config.Users {
-				if u.Name == *c.User {
-					user = &u
-					break
+			if UserExists(c) {
+				for _, u := range config.Users {
+					if u.Name == *c.User {
+						user = &u
+						break
+					}
 				}
 			}
 		}
@@ -99,40 +101,16 @@ func CurrentContext() (endpoint Endpoint, user *User) {
 func GetCurrentContextInfo() (server string, username string, password string) {
 	endpoint, user := CurrentContext()
 	server = fmt.Sprintf("%s,%d", endpoint.Address, endpoint.Port)
-	username = user.BasicAuth.Username
-	if user.AuthenticationType == "basic" {
-		password = decryptCallback(
-			user.BasicAuth.Password,
-			user.BasicAuth.PasswordEncrypted,
-		)
-	}
-	return
-}
-
-// isCurrentContextValid returns true if it has valid information associated
-// such as endpoint and user.
-func IsCurrentContextValid() (isValid bool) {
-	currentContextName := CurrentContextName()
-	endPointFound := false
-	userFound := false
-	for _, c := range config.Contexts {
-		if c.Name == currentContextName {
-			for _, e := range config.Endpoints {
-				if e.Name == c.Endpoint {
-					endPointFound = true
-					break
-				}
-			}
-
-			for _, u := range config.Users {
-				if u.Name == *c.User && u.Name != "" {
-					userFound = true
-					break
-				}
-			}
+	if user != nil {
+		username = user.BasicAuth.Username
+		if user.AuthenticationType == "basic" {
+			password = decryptCallback(
+				user.BasicAuth.Password,
+				user.BasicAuth.PasswordEncrypted,
+			)
 		}
 	}
-	return endPointFound && userFound
+	return
 }
 
 // DeleteContext removes the context with the given name from the application's

--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -5,8 +5,9 @@ package config
 
 import (
 	"fmt"
-	. "github.com/microsoft/go-sqlcmd/cmd/modern/sqlconfig"
 	"strconv"
+
+	. "github.com/microsoft/go-sqlcmd/cmd/modern/sqlconfig"
 )
 
 // AddUser adds a new user to the configuration.
@@ -122,4 +123,10 @@ func userOrdinal(name string) (ordinal int) {
 		}
 	}
 	return
+}
+
+// UserExists checks if the current context has a 'user', e.g. a context used
+// for trusted authentication will not have a user.
+func UserExists(context Context) bool {
+	return context.ContextDetails.User != nil && *context.ContextDetails.User != ""
 }


### PR DESCRIPTION
sqlcmd when invoked with no arguments, executes in backward compat mode and ignore current-context info for establishing connection. This commit changes the default behavior to establish connection to the endpoint associated with current-context if valid user details exits in sqlcmd config file.
This ensures that users can connect to sql server instance created by sqlcmd if no arguments are specified while invoking sqlcmd.

```
\git\go-sqlcmd>.\sqlcmd.exe
1> select @@servername
2> go

--------------------------------------------------------------------------------------------------------------------------------
LAPTOP-VPBI3ASB

(1 row affected)
1> exit

git\go-sqlcmd>.\sqlcmd.exe create mssql --accept-eula
Downloading mcr.microsoft.com/mssql/server:latest
Starting mcr.microsoft.com/mssql/server:latest
Created context "mssql" in "C:\Users\apdeshmukh\.sqlcmd\sqlconfig", configuring user account...
Disabled "sa" account (and rotated "sa" password). Creating user "apdeshmukh"
Now ready for client connections on port 1435

HINT:
  1. Open in Azure Data Studio: sqlcmd open ads
  2. Run a query:               sqlcmd query "SELECT @@version"
  3. Start interactive session: sqlcmd query
  4. View sqlcmd configuration: sqlcmd config view
  5. See connection strings:    sqlcmd config connection-strings
  6. Remove:                    sqlcmd delete


\git\go-sqlcmd>.\sqlcmd.exe
1> select @@servername
2> go

--------------------------------------------------------------------------------------------------------------------------------
4ee585f27077

(1 row affected)
1>
```