### PR TITLE
create a sqlcmd style linter

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -249,6 +249,38 @@ SOFTWARE.
 
 ```
 
+## github.com/cespare/xxhash/v2
+
+* Name: github.com/cespare/xxhash/v2
+* Version: v2.1.1
+* License: [MIT](https://github.com/cespare/xxhash/blob/v2.1.1/LICENSE.txt)
+
+```
+Copyright (c) 2016 Caleb Spare
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
 ## github.com/docker/distribution
 
 * Name: github.com/docker/distribution
@@ -1612,9 +1644,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
-## github.com/golang/protobuf/proto
+## github.com/golang/protobuf
 
-* Name: github.com/golang/protobuf/proto
+* Name: github.com/golang/protobuf
 * Version: v1.5.2
 * License: [BSD-3-Clause](https://github.com/golang/protobuf/blob/v1.5.2/LICENSE)
 
@@ -3352,8 +3384,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/client_golang/prometheus
 
 * Name: github.com/prometheus/client_golang/prometheus
-* Version: v1.1.0
-* License: [Apache-2.0](https://github.com/prometheus/client_golang/blob/v1.1.0/LICENSE)
+* Version: v1.11.1
+* License: [Apache-2.0](https://github.com/prometheus/client_golang/blob/v1.11.1/LICENSE)
 
 ```
                                  Apache License
@@ -3563,8 +3595,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/client_model/go
 
 * Name: github.com/prometheus/client_model/go
-* Version: v0.0.0-20190812154241-14fe0d1b01d4
-* License: [Apache-2.0](https://github.com/prometheus/client_model/blob/14fe0d1b01d4/LICENSE)
+* Version: v0.2.0
+* License: [Apache-2.0](https://github.com/prometheus/client_model/blob/v0.2.0/LICENSE)
 
 ```
                                  Apache License
@@ -3774,8 +3806,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/common
 
 * Name: github.com/prometheus/common
-* Version: v0.6.0
-* License: [Apache-2.0](https://github.com/prometheus/common/blob/v0.6.0/LICENSE)
+* Version: v0.26.0
+* License: [Apache-2.0](https://github.com/prometheus/common/blob/v0.26.0/LICENSE)
 
 ```
                                  Apache License
@@ -3985,8 +4017,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 
 * Name: github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
-* Version: v0.6.0
-* License: [BSD-3-Clause](https://github.com/prometheus/common/blob/v0.6.0/internal\bitbucket.org\ww\goautoneg\README.txt)
+* Version: v0.26.0
+* License: [BSD-3-Clause](https://github.com/prometheus/common/blob/v0.26.0/internal\bitbucket.org\ww\goautoneg\README.txt)
 
 ```
 PACKAGE
@@ -4657,8 +4689,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/net
 
 * Name: golang.org/x/net
-* Version: v0.0.0-20221014081412-f15817d10f9b
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/net/+/f15817d1:LICENSE)
+* Version: v0.7.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/net/+/v0.7.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4694,8 +4726,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/sys
 
 * Name: golang.org/x/sys
-* Version: v0.0.0-20220908164124-27713097b956
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/27713097:LICENSE)
+* Version: v0.5.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.5.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4731,8 +4763,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/text
 
 * Name: golang.org/x/text
-* Version: v0.4.0
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/text/+/v0.4.0:LICENSE)
+* Version: v0.7.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/text/+/v0.7.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/cmd/sqlcmd-linter/main.go
+++ b/cmd/sqlcmd-linter/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	sqlcmdlinter "github.com/microsoft/go-sqlcmd/pkg/sqlcmd-linter"
+	"golang.org/x/tools/go/analysis/multichecker"
+)
+
+func main() {
+	multichecker.Main(sqlcmdlinter.AssertAnalyzer)
+}

--- a/pkg/sqlcmd-linter/testdata/src/github.com/README.md
+++ b/pkg/sqlcmd-linter/testdata/src/github.com/README.md
@@ -1,0 +1,1 @@
+This directory structure exists to provide stub package implementations for the linter tests. The `analysistest` package replaces `$GOPATH` with the local file system path. We create these stubs so the linter test files can closely mimic our production code.

--- a/pkg/sqlcmd-linter/testdata/src/github.com/stretchr/testify/assert/main.go
+++ b/pkg/sqlcmd-linter/testdata/src/github.com/stretchr/testify/assert/main.go
@@ -1,0 +1,11 @@
+package assert
+
+import "testing"
+
+func NotNil(t *testing.T, object interface{}, msgAndArgs ...interface{}) bool {
+	return false
+}
+
+func NoError(t *testing.T, err error, msgAndArgs ...interface{}) bool {
+	return false
+}

--- a/pkg/sqlcmd-linter/testdata/src/useassert_linter_tests/assert.go
+++ b/pkg/sqlcmd-linter/testdata/src/useassert_linter_tests/assert.go
@@ -1,0 +1,21 @@
+package sqlcmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDontUseFatal(t *testing.T) {
+	t.Fatal("this should fail")        // want "Use assert package methods instead of Fatal"
+	t.Fatalf("this should %s", "fail") // want "Use assert package methods instead of Fatalf"
+	t.Fail()                           // want "Use assert package methods instead of Fail"
+	assert.NoError(t, fmt.Errorf("what"))
+	t.FailNow() // want "Use assert package methods instead of FailNow"
+
+}
+
+func TestDontUseRecover(t *testing.T) {
+	defer func() { assert.NotNil(t, recover(), "The code did not panic as expected") }() // want "Use assert.Panics instead of recover()"
+}

--- a/pkg/sqlcmd-linter/useasserts.go
+++ b/pkg/sqlcmd-linter/useasserts.go
@@ -1,0 +1,55 @@
+package sqlcmdlinter
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var AssertAnalyzer = &analysis.Analyzer{
+	Name:     "assertlint",
+	Doc:      "Require use of asserts instead of fmt.Error functions in tests",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+var blockedTestingMethods = []string{"Error", "ErrorF", "Fail", "FailNow", "Fatal", "Fatalf"}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	// pass.ResultOf[inspect.Analyzer] will be set if we've added inspect.Analyzer to Requires.
+	// Analyze code and make an AST from the file:
+	inspectorInstance := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{(*ast.CallExpr)(nil)}
+
+	inspectorInstance.Preorder(nodeFilter, func(n ast.Node) {
+		node := n.(*ast.CallExpr)
+		switch fun := node.Fun.(type) {
+		case (*ast.SelectorExpr):
+			switch funX := fun.X.(type) {
+			case (*ast.Ident):
+				if funX.Name == "t" && contains(blockedTestingMethods, fun.Sel.Name) {
+					pass.Reportf(node.Pos(), "Use assert package methods instead of %s", fun.Sel.Name)
+				}
+			default:
+				return
+			}
+		case (*ast.Ident):
+			if fun.Name == "recover" {
+				pass.Reportf(node.Pos(), "Use assert.Panics instead of recover()")
+			}
+		}
+	})
+	return nil, nil
+}
+
+func contains(a []string, v string) bool {
+	for _, val := range a {
+		if val == v {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sqlcmd-linter/useasserts_test.go
+++ b/pkg/sqlcmd-linter/useasserts_test.go
@@ -1,0 +1,17 @@
+package sqlcmdlinter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestUseAsserts(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Failed to get wd: %s", err)
+	}
+	analysistest.Run(t, filepath.Join(wd, `testdata`), AssertAnalyzer, "useassert_linter_tests/...")
+}


### PR DESCRIPTION
Fixes #214 
- Iteration 1 adds a basic linter skeleton with one linter that flags use of non-`assert` test failure methods like `t.Fatalf`
- Adds use of the linter to `build\build.cmd` to print out any warnings. Once we are clean we can convert the linter run to a step in the PR validation pipeline.
- Iteration 2 will add enforcement of package import/hierarchy rules. 