### PR TITLE
Don't use SQLCMDPASSWORD env var if SQLCMDUSER env var not set

### DIFF
--- a/cmd/modern/main.go
+++ b/cmd/modern/main.go
@@ -62,13 +62,20 @@ func initializeEnvVars() {
 		if os.Getenv("SQLCMDSERVER") == "" {
 			os.Setenv("SQLCMDSERVER", server)
 		}
-		if os.Getenv("SQLCMDUSER") == "" {
-			os.Setenv("SQLCMDUSER", username)
+
+		// Username and password should come together, either from the environment
+		// variables set by the user before the sqlcmd process started, or from the sqlconfig
+		// for the current context, but if just the environment variable SQLCMDPASSWORD
+		// is set before the process starts we do not use it, if the user and password is set in sqlconfig.
+		if username != "" && password != "" { // If not trusted auth
+			if os.Getenv("SQLCMDUSER") == "" {
+				os.Setenv("SQLCMDUSER", username)
+				os.Setenv("SQLCMDPASSWORD", password)
+			}
 		}
-		if os.Getenv("SQLCMDPASSWORD") == "" {
-			os.Setenv("SQLCMDPASSWORD", password)
-		}
+
 	}
+
 }
 
 // isFirstArgModernCliSubCommand is TEMPORARY code, to be removed when


### PR DESCRIPTION
If users have set SQLCMDPASSWORD as part of normal sqlcmd usage, we were using that, when SQLCMDUSER was not set (and setting SQLCMDUSER from sqlconfig file), this was causing login failures.