### PR TITLE
Add console syntax coloring

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -159,6 +159,35 @@ SOFTWARE.
 
 ```
 
+## github.com/alecthomas/chroma/v2
+
+* Name: github.com/alecthomas/chroma/v2
+* Version: v2.5.0
+* License: [MIT](https://github.com/alecthomas/chroma/blob/v2.5.0/COPYING)
+
+```
+Copyright (C) 2017 Alec Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
 ## github.com/alecthomas/kong
 
 * Name: github.com/alecthomas/kong
@@ -228,6 +257,69 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 MIT License
 
 Copyright (c) 2019 Bill Graziano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+## github.com/cespare/xxhash/v2
+
+* Name: github.com/cespare/xxhash/v2
+* Version: v2.1.1
+* License: [MIT](https://github.com/cespare/xxhash/blob/v2.1.1/LICENSE.txt)
+
+```
+Copyright (c) 2016 Caleb Spare
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
+## github.com/dlclark/regexp2
+
+* Name: github.com/dlclark/regexp2
+* Version: v1.4.0
+* License: [MIT](https://github.com/dlclark/regexp2/blob/v1.4.0/LICENSE)
+
+```
+The MIT License (MIT)
+
+Copyright (c) Doug Clark
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1612,9 +1704,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
-## github.com/golang/protobuf/proto
+## github.com/golang/protobuf
 
-* Name: github.com/golang/protobuf/proto
+* Name: github.com/golang/protobuf
 * Version: v1.5.2
 * License: [BSD-3-Clause](https://github.com/golang/protobuf/blob/v1.5.2/LICENSE)
 
@@ -3352,8 +3444,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/client_golang/prometheus
 
 * Name: github.com/prometheus/client_golang/prometheus
-* Version: v1.1.0
-* License: [Apache-2.0](https://github.com/prometheus/client_golang/blob/v1.1.0/LICENSE)
+* Version: v1.11.1
+* License: [Apache-2.0](https://github.com/prometheus/client_golang/blob/v1.11.1/LICENSE)
 
 ```
                                  Apache License
@@ -3563,8 +3655,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/client_model/go
 
 * Name: github.com/prometheus/client_model/go
-* Version: v0.0.0-20190812154241-14fe0d1b01d4
-* License: [Apache-2.0](https://github.com/prometheus/client_model/blob/14fe0d1b01d4/LICENSE)
+* Version: v0.2.0
+* License: [Apache-2.0](https://github.com/prometheus/client_model/blob/v0.2.0/LICENSE)
 
 ```
                                  Apache License
@@ -3774,8 +3866,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/common
 
 * Name: github.com/prometheus/common
-* Version: v0.6.0
-* License: [Apache-2.0](https://github.com/prometheus/common/blob/v0.6.0/LICENSE)
+* Version: v0.26.0
+* License: [Apache-2.0](https://github.com/prometheus/common/blob/v0.26.0/LICENSE)
 
 ```
                                  Apache License
@@ -3985,8 +4077,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 
 * Name: github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
-* Version: v0.6.0
-* License: [BSD-3-Clause](https://github.com/prometheus/common/blob/v0.6.0/internal\bitbucket.org\ww\goautoneg\README.txt)
+* Version: v0.26.0
+* License: [BSD-3-Clause](https://github.com/prometheus/common/blob/v0.26.0/internal\bitbucket.org\ww\goautoneg\README.txt)
 
 ```
 PACKAGE
@@ -4657,8 +4749,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/net
 
 * Name: golang.org/x/net
-* Version: v0.0.0-20221014081412-f15817d10f9b
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/net/+/f15817d1:LICENSE)
+* Version: v0.7.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/net/+/v0.7.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4694,8 +4786,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/sys
 
 * Name: golang.org/x/sys
-* Version: v0.0.0-20220908164124-27713097b956
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/27713097:LICENSE)
+* Version: v0.5.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.5.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4731,8 +4823,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/text
 
 * Name: golang.org/x/text
-* Version: v0.4.0
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/text/+/v0.4.0:LICENSE)
+* Version: v0.7.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/text/+/v0.7.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ We will be implementing command line switches and behaviors over time. Several s
 
 ### Miscellaneous enhancements
 
+- Console output coloring (see below)
 - `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlAuthentication`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` user name parameter.
 - The new `--driver-logging-level` command line parameter allows you to see traces from the `go-mssqldb` client driver. Use `64` to see all traces.
 - Sqlcmd can now print results using a vertical format. Use the new `-F vertical` command line option to set it. It's also controlled by the `SQLCMDFORMAT` scripting variable.
@@ -106,6 +107,17 @@ Some settings for AAD auth do not have command line inputs, and some environment
 These environment variables can be set to configure some aspects of AAD auth and to bypass default behaviors. In addition to the variables listed above, the following are sqlcmd-specific and apply to multiple methods.
 
 `SQLCMDCLIENTID` - set this to the identifier of an application registered in your AAD which is authorized to authenticate to Azure SQL Database. Applies to `ActiveDirectoryInteractive` and `ActiveDirectoryPassword` methods.
+
+## Console colors
+
+Sqlcmd now supports syntax coloring the output of `:list` and the results of TSQL queries when output to the terminal.
+To enable coloring use the `SQLCMDCOLORSCHEME` variable, which can be set as an environment variable or by using `:setvar`. The valid values are the names of styles supported by the [chroma styles](https://github.com/alecthomas/chroma/tree/master/styles) project. 
+
+To see a list of available styles along with colored syntax samples, use this command in interactive mode:
+
+```
+:list color
+```
 
 ### Packages
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/microsoft/go-sqlcmd
 go 1.18
 
 require (
+	github.com/alecthomas/chroma/v2 v2.5.0
 	github.com/alecthomas/kong v0.6.2-0.20220922001058-c62bf25854a0
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/docker/distribution v2.8.1+incompatible
@@ -30,6 +31,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,14 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
-github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
+github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=
+github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
+github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
+github.com/alecthomas/chroma/v2 v2.5.0 h1:CQCdj1BiBV17sD4Bd32b/Bzuiq/EqoNTrnIhyQAZ+Rk=
+github.com/alecthomas/chroma/v2 v2.5.0/go.mod h1:yrkMI9807G1ROx13fhe1v6PN2DDeaR73L3d+1nmYQtw=
 github.com/alecthomas/kong v0.6.2-0.20220922001058-c62bf25854a0 h1:HQ3WlFsqBcr4qsiHtfA7UdFSrChglOcQa8q/tbXJFBI=
 github.com/alecthomas/kong v0.6.2-0.20220922001058-c62bf25854a0/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
-github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -79,6 +83,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -2,6 +2,7 @@ package color
 
 import (
 	"io"
+	"os"
 
 	"github.com/alecthomas/chroma/v2/quick"
 )
@@ -28,27 +29,41 @@ const (
 
 // Colorizer has methods to write colorized text to a stream and to add color to HTML content
 type Colorizer interface {
-	// Write prints s to w using the current color scheme. It assumes w is compatible with ANSI color codes.
-	Write(w io.Writer, s string, t TextType)
+	// Write prints s to w using the current color scheme. If w is not a terminal or if it is redirected, no color codes are printed
+	Write(w io.Writer, s string, scheme string, t TextType)
 }
 
 type chromaColorizer struct {
-	scheme string
+	forceColor bool
 }
 
-func New(scheme string) Colorizer {
-	return &chromaColorizer{scheme: scheme}
+func New(forceColor bool) Colorizer {
+	return &chromaColorizer{forceColor: forceColor}
 }
 
-func (c *chromaColorizer) Write(w io.Writer, s string, t TextType) {
-	if c.scheme == "" {
+func (c *chromaColorizer) Write(w io.Writer, s string, scheme string, t TextType) {
+	colorize := scheme != ""
+	// only colorize if w is a terminal and it's not redirected, or if forceColor is set
+	if colorize && !c.forceColor {
+		if f, ok := w.(*os.File); ok {
+			if f == os.Stdout || f == os.Stderr {
+				i, _ := f.Stat()
+				colorize = (i.Mode() & os.ModeCharDevice) == os.ModeCharDevice
+			} else {
+				colorize = false
+			}
+		} else {
+			colorize = false
+		}
+	}
+	if !colorize {
 		t = TextTypeNormal
 	}
 	switch t {
 	case TextTypeNormal:
 		_, _ = w.Write([]byte(s))
 	case TextTypeTSql:
-		if err := quick.Highlight(w, s, "transact-sql", "terminal256", c.scheme); err != nil {
+		if err := quick.Highlight(w, s, "transact-sql", "terminal256", scheme); err != nil {
 			_, _ = w.Write([]byte(s))
 		}
 	}

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,55 @@
+package color
+
+import (
+	"io"
+
+	"github.com/alecthomas/chroma/v2/quick"
+)
+
+// TextType defines a category of text that can be colorized
+type TextType int
+
+const (
+	// TextTypeNormal is non-categorized text that prints with the default color
+	TextTypeNormal TextType = iota
+	// TextTypeTSql is for transact-sql syntax
+	TextTypeTSql
+	// TextTypeHeader is for a table column header or cell label
+	TextTypeHeader
+	// TextTypeCell is for a cell value
+	TextTypeCell
+	// TextTypeSeparator is for characters that delimit columns and rows
+	TextTypeSeparator
+	// TextTypeError is for error messages
+	TextTypeError
+	// TextTypeWarning is for warning messages
+	TextTypeWarning
+)
+
+// Colorizer has methods to write colorized text to a stream and to add color to HTML content
+type Colorizer interface {
+	// Write prints s to w using the current color scheme. It assumes w is compatible with ANSI color codes.
+	Write(w io.Writer, s string, t TextType)
+}
+
+type chromaColorizer struct {
+	scheme string
+}
+
+func New(scheme string) Colorizer {
+	return &chromaColorizer{scheme: scheme}
+}
+
+func (c *chromaColorizer) Write(w io.Writer, s string, t TextType) {
+	if c.scheme == "" {
+		t = TextTypeNormal
+	}
+	switch t {
+	case TextTypeNormal:
+		_, _ = w.Write([]byte(s))
+	case TextTypeTSql:
+		if err := quick.Highlight(w, s, "transact-sql", "terminal256", c.scheme); err != nil {
+			_, _ = w.Write([]byte(s))
+		}
+	}
+}

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -14,7 +14,6 @@ func TestWrite(t *testing.T) {
 	}
 	colorizer := New(true)
 	noncolorizer := New(false)
-
 	tests := []struct {
 		name  string
 		args  args
@@ -65,7 +64,8 @@ func TestWrite(t *testing.T) {
 			gotW := w.String()
 			assert.Equalf(t, tt.wantW, gotW, "colorizer.Write(%+v)", tt.args)
 			w.Reset()
-			noncolorizer.Write(w, tt.args.s, "emacs", tt.args.t)
+			err = noncolorizer.Write(w, tt.args.s, "emacs", tt.args.t)
+			assert.NoErrorf(t, err, "nonColorizer.Write returned an error %+v", tt.args)
 			assert.Equalf(t, tt.args.s, w.String(), "noncolorizer.Write should write unmodified string")
 
 		})

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -12,8 +12,8 @@ func TestWrite(t *testing.T) {
 		s string
 		t TextType
 	}
-	colorizer := New("emacs")
-	noncolorizer := New("")
+	colorizer := New(true)
+	noncolorizer := New(false)
 
 	tests := []struct {
 		name  string
@@ -35,11 +35,11 @@ func TestWrite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &bytes.Buffer{}
-			colorizer.Write(w, tt.args.s, tt.args.t)
+			colorizer.Write(w, tt.args.s, "emacs", tt.args.t)
 			gotW := w.String()
 			assert.Equalf(t, tt.wantW, gotW, "colorizer.Write(%+v)", tt.args)
 			w.Reset()
-			noncolorizer.Write(w, tt.args.s, tt.args.t)
+			noncolorizer.Write(w, tt.args.s, "emacs", tt.args.t)
 			assert.Equalf(t, tt.args.s, w.String(), "noncolorizer.Write should write unmodified string")
 
 		})

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -30,12 +30,38 @@ func TestWrite(t *testing.T) {
 			args:  args{s: "select top (1) name from sys.tables", t: TextTypeTSql},
 			wantW: "\x1b[1m\x1b[38;5;129mselect\x1b[0m\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mtop\x1b[0m\x1b[38;5;250m \x1b[0m(\x1b[38;5;241m1\x1b[0m)\x1b[38;5;250m \x1b[0mname\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mfrom\x1b[0m\x1b[38;5;250m \x1b[0msys.tables",
 		},
+		{
+			name:  "Header",
+			args:  args{s: "header", t: TextTypeHeader},
+			wantW: "\x1b[1m\x1b[38;5;4mheader\x1b[0m",
+		},
+		{
+			name:  "Cell",
+			args:  args{s: "cell", t: TextTypeCell},
+			wantW: "\x1b[38;5;2mcell\x1b[0m",
+		},
+		{
+			name:  "Separator",
+			args:  args{s: "sep", t: TextTypeSeparator},
+			wantW: "\x1b[38;5;131msep\x1b[0m",
+		},
+		{
+			name:  "Error",
+			args:  args{s: "error", t: TextTypeError},
+			wantW: "\x1b[38;5;196merror\x1b[0m",
+		},
+		{
+			name:  "Warning",
+			args:  args{s: "warn", t: TextTypeWarning},
+			wantW: "\x1b[3mwarn\x1b[0m",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &bytes.Buffer{}
-			colorizer.Write(w, tt.args.s, "emacs", tt.args.t)
+			err := colorizer.Write(w, tt.args.s, "emacs", tt.args.t)
+			assert.NoErrorf(t, err, "Write returned an error %+v", tt.args)
 			gotW := w.String()
 			assert.Equalf(t, tt.wantW, gotW, "colorizer.Write(%+v)", tt.args)
 			w.Reset()

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -28,27 +28,27 @@ func TestWrite(t *testing.T) {
 		{
 			name:  "TSQL",
 			args:  args{s: "select top (1) name from sys.tables", t: TextTypeTSql},
-			wantW: "\x1b[1m\x1b[38;5;129mselect\x1b[0m\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mtop\x1b[0m\x1b[38;5;250m \x1b[0m(\x1b[38;5;241m1\x1b[0m)\x1b[38;5;250m \x1b[0mname\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mfrom\x1b[0m\x1b[38;5;250m \x1b[0msys.tables",
+			wantW: "\x1b[1m\x1b[38;2;170;34;255mselect\x1b[0m\x1b[38;2;187;187;187m \x1b[0m\x1b[1m\x1b[38;2;170;34;255mtop\x1b[0m\x1b[38;2;187;187;187m \x1b[0m(\x1b[38;2;102;102;102m1\x1b[0m)\x1b[38;2;187;187;187m \x1b[0mname\x1b[38;2;187;187;187m \x1b[0m\x1b[1m\x1b[38;2;170;34;255mfrom\x1b[0m\x1b[38;2;187;187;187m \x1b[0msys.tables",
 		},
 		{
 			name:  "Header",
 			args:  args{s: "header", t: TextTypeHeader},
-			wantW: "\x1b[1m\x1b[38;5;4mheader\x1b[0m",
+			wantW: "\x1b[1m\x1b[38;2;0;0;128mheader\x1b[0m",
 		},
 		{
 			name:  "Cell",
 			args:  args{s: "cell", t: TextTypeCell},
-			wantW: "\x1b[38;5;2mcell\x1b[0m",
+			wantW: "\x1b[38;2;0;128;0mcell\x1b[0m",
 		},
 		{
 			name:  "Separator",
 			args:  args{s: "sep", t: TextTypeSeparator},
-			wantW: "\x1b[38;5;131msep\x1b[0m",
+			wantW: "\x1b[38;2;187;68;68msep\x1b[0m",
 		},
 		{
 			name:  "Error",
 			args:  args{s: "error", t: TextTypeError},
-			wantW: "\x1b[38;5;196merror\x1b[0m",
+			wantW: "\x1b[38;2;255;0;0merror\x1b[0m",
 		},
 		{
 			name:  "Warning",
@@ -70,4 +70,10 @@ func TestWrite(t *testing.T) {
 
 		})
 	}
+}
+
+func TestStyles(t *testing.T) {
+	c := New(false)
+	s := c.Styles()
+	assert.Contains(t, s, "emacs", "emacs style not found")
 }

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -1,0 +1,47 @@
+package color
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrite(t *testing.T) {
+	type args struct {
+		s string
+		t TextType
+	}
+	colorizer := New("emacs")
+	noncolorizer := New("")
+
+	tests := []struct {
+		name  string
+		args  args
+		wantW string
+	}{
+		{
+			name:  "Normal",
+			args:  args{s: "select 100", t: TextTypeNormal},
+			wantW: "select 100",
+		},
+		{
+			name:  "TSQL",
+			args:  args{s: "select top (1) name from sys.tables", t: TextTypeTSql},
+			wantW: "\x1b[1m\x1b[38;5;129mselect\x1b[0m\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mtop\x1b[0m\x1b[38;5;250m \x1b[0m(\x1b[38;5;241m1\x1b[0m)\x1b[38;5;250m \x1b[0mname\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mfrom\x1b[0m\x1b[38;5;250m \x1b[0msys.tables",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			colorizer.Write(w, tt.args.s, tt.args.t)
+			gotW := w.String()
+			assert.Equalf(t, tt.wantW, gotW, "colorizer.Write(%+v)", tt.args)
+			w.Reset()
+			noncolorizer.Write(w, tt.args.s, tt.args.t)
+			assert.Equalf(t, tt.args.s, w.String(), "noncolorizer.Write should write unmodified string")
+
+		})
+	}
+}

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -370,9 +370,9 @@ func listCommand(s *Sqlcmd, args []string, line uint) (err error) {
 	if cmd == "color" {
 		// ignoring errors since it's not critical output
 		for _, style := range s.colorizer.Styles() {
-			output.Write([]byte(style + ": "))
-			s.colorizer.Write(output, "select 'literal' as literal, 100 as number from [sys].[tables]", style, color.TextTypeTSql)
-			output.Write([]byte(SqlcmdEol))
+			_, _ = output.Write([]byte(style + ": "))
+			_ = s.colorizer.Write(output, "select 'literal' as literal, 100 as number from [sys].[tables]", style, color.TextTypeTSql)
+			_, _ = output.Write([]byte(SqlcmdEol))
 		}
 		return
 	}

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -356,15 +356,17 @@ func resetCommand(s *Sqlcmd, args []string, line uint) error {
 }
 
 // listCommand displays statements currently in  the statement cache
-func listCommand(s *Sqlcmd, args []string, line uint) error {
+func listCommand(s *Sqlcmd, args []string, line uint) (err error) {
 	if s.batch == nil || s.batch.String() == "" {
-		return nil
+		return
 	}
 
 	output := s.GetOutput()
-	s.colorizer.Write(output, s.batch.String(), s.vars.ColorScheme(), color.TextTypeTSql)
-	output.Write([]byte(SqlcmdEol))
-	return nil
+	if err = s.colorizer.Write(output, s.batch.String(), s.vars.ColorScheme(), color.TextTypeTSql); err == nil {
+		_, err = output.Write([]byte(SqlcmdEol))
+	}
+
+	return
 }
 
 type connectData struct {

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -357,11 +357,29 @@ func resetCommand(s *Sqlcmd, args []string, line uint) error {
 
 // listCommand displays statements currently in  the statement cache
 func listCommand(s *Sqlcmd, args []string, line uint) (err error) {
+	cmd := ""
+	if args != nil {
+		if len(args) > 0 {
+			cmd = strings.ToLower(strings.TrimSpace(args[0]))
+			if len(args) > 1 || (cmd != "color" && cmd != "") {
+				return InvalidCommandError("LIST", line)
+			}
+		}
+	}
+	output := s.GetOutput()
+	if cmd == "color" {
+		// ignoring errors since it's not critical output
+		for _, style := range s.colorizer.Styles() {
+			output.Write([]byte(style + ": "))
+			s.colorizer.Write(output, "select 'literal' as literal, 100 as number from [sys].[tables]", style, color.TextTypeTSql)
+			output.Write([]byte(SqlcmdEol))
+		}
+		return
+	}
 	if s.batch == nil || s.batch.String() == "" {
 		return
 	}
 
-	output := s.GetOutput()
 	if err = s.colorizer.Write(output, s.batch.String(), s.vars.ColorScheme(), color.TextTypeTSql); err == nil {
 		_, err = output.Write([]byte(SqlcmdEol))
 	}

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"github.com/microsoft/go-sqlcmd/internal/color"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -356,10 +357,13 @@ func resetCommand(s *Sqlcmd, args []string, line uint) error {
 
 // listCommand displays statements currently in  the statement cache
 func listCommand(s *Sqlcmd, args []string, line uint) error {
-	if s.batch != nil && s.batch.String() != "" {
-		fmt.Fprintf(s.GetOutput(), `%s%s`, []byte(s.batch.String()), SqlcmdEol)
+	if s.batch == nil || s.batch.String() == "" {
+		return nil
 	}
 
+	output := s.GetOutput()
+	s.colorizer.Write(output, s.batch.String(), s.vars.ColorScheme(), color.TextTypeTSql)
+	output.Write([]byte(SqlcmdEol))
 	return nil
 }
 

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -181,7 +181,20 @@ func TestListCommandUsesColorizer(t *testing.T) {
 	assert.NoError(t, err, "Executing :list command")
 	s.SetOutput(nil)
 	o := buf.buf.String()
-	assert.Equal(t, "\x1b[1m\x1b[38;5;129mselect\x1b[0m\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mtop\x1b[0m\x1b[38;5;250m \x1b[0m(\x1b[38;5;241m1\x1b[0m)\x1b[38;5;250m \x1b[0mname\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mfrom\x1b[0m\x1b[38;5;250m \x1b[0msys.tables"+SqlcmdEol, o, ":list output not equal to batch")
+	assert.Equal(t, "\x1b[1m\x1b[38;2;170;34;255mselect\x1b[0m\x1b[38;2;187;187;187m \x1b[0m\x1b[1m\x1b[38;2;170;34;255mtop\x1b[0m\x1b[38;2;187;187;187m \x1b[0m(\x1b[38;2;102;102;102m1\x1b[0m)\x1b[38;2;187;187;187m \x1b[0mname\x1b[38;2;187;187;187m \x1b[0m\x1b[1m\x1b[38;2;170;34;255mfrom\x1b[0m\x1b[38;2;187;187;187m \x1b[0msys.tables"+SqlcmdEol, o, ":list output not equal to batch")
+}
+
+func TestListColorPrintsStyleSamples(t *testing.T) {
+	vars := InitializeVariables(false)
+	s := New(nil, "", vars)
+	// force colorizer on
+	s.colorizer = color.New(true)
+	buf := &memoryBuffer{buf: new(bytes.Buffer)}
+	s.SetOutput(buf)
+	runSqlCmd(t, s, []string{":list color"})
+	s.SetOutput(nil)
+	o := buf.buf.String()[:600]
+	assert.Containsf(t, o, "algol_nu: \x1b[1mselect\x1b[0m \x1b[3m\x1b[38;2;102;102;102m'literal'\x1b[0m \x1b[1mas\x1b[0m literal, 100 \x1b[1mas\x1b[0m number \x1b[1mfrom\x1b[0m [sys].[tables]", "expected entry not found for algol_nu %s", o)
 }
 
 func TestConnectCommand(t *testing.T) {

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -191,7 +191,8 @@ func TestListColorPrintsStyleSamples(t *testing.T) {
 	s.colorizer = color.New(true)
 	buf := &memoryBuffer{buf: new(bytes.Buffer)}
 	s.SetOutput(buf)
-	runSqlCmd(t, s, []string{":list color"})
+	err := runSqlCmd(t, s, []string{":list color"})
+	assert.NoError(t, err, ":list color returned error")
 	s.SetOutput(nil)
 	o := buf.buf.String()[:600]
 	assert.Containsf(t, o, "algol_nu: \x1b[1mselect\x1b[0m \x1b[3m\x1b[38;2;102;102;102m'literal'\x1b[0m \x1b[1mas\x1b[0m literal, 100 \x1b[1mas\x1b[0m number \x1b[1mfrom\x1b[0m [sys].[tables]", "expected entry not found for algol_nu %s", o)

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/go-mssqldb/azuread"
+	"github.com/microsoft/go-sqlcmd/internal/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,6 +160,28 @@ func TestListCommand(t *testing.T) {
 	s.SetOutput(nil)
 	o := buf.buf.String()
 	assert.Equal(t, o, "select 1"+SqlcmdEol, ":list output not equal to batch")
+}
+
+func TestListCommandUsesColorizer(t *testing.T) {
+	vars := InitializeVariables(false)
+	vars.Set(SQLCMDCOLORSCHEME, "emacs")
+	s := New(nil, "", vars)
+	// force colorizer on
+	s.colorizer = color.New(true)
+	buf := &memoryBuffer{buf: new(bytes.Buffer)}
+	s.SetOutput(buf)
+
+	// insert test batch
+	s.batch.Reset([]rune("select top (1) name from sys.tables"))
+	_, _, err := s.batch.Next()
+	assert.NoError(t, err, "Inserting test batch")
+
+	// execute list command and verify results
+	err = listCommand(s, nil, 1)
+	assert.NoError(t, err, "Executing :list command")
+	s.SetOutput(nil)
+	o := buf.buf.String()
+	assert.Equal(t, "\x1b[1m\x1b[38;5;129mselect\x1b[0m\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mtop\x1b[0m\x1b[38;5;250m \x1b[0m(\x1b[38;5;241m1\x1b[0m)\x1b[38;5;250m \x1b[0mname\x1b[38;5;250m \x1b[0m\x1b[1m\x1b[38;5;129mfrom\x1b[0m\x1b[38;5;250m \x1b[0msys.tables"+SqlcmdEol, o, ":list output not equal to batch")
 }
 
 func TestConnectCommand(t *testing.T) {

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -146,5 +146,5 @@ func TestFormatterColorizer(t *testing.T) {
 	s.vars.Set(SQLCMDCOLORSCHEME, "emacs")
 	s.Format.(*sqlCmdFormatterType).colorizer = color.New(true)
 	runSqlCmd(t, s, []string{"select 'name' as name", "GO"})
-	assert.Equal(t, "\x1b[38;2;0;128;0mname\x1b[0m\r\n\r\n\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
+	assert.Equal(t, "\x1b[38;2;0;128;0mname\x1b[0m"+SqlcmdEol+SqlcmdEol+"\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
 }

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -146,5 +146,5 @@ func TestFormatterColorizer(t *testing.T) {
 	s.vars.Set(SQLCMDCOLORSCHEME, "emacs")
 	s.Format.(*sqlCmdFormatterType).colorizer = color.New(true)
 	runSqlCmd(t, s, []string{"select 'name' as name", "GO"})
-	assert.Equal(t, "\x1b[38;5;2mname\x1b[0m"+SqlcmdEol+SqlcmdEol+"\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
+	assert.Equal(t, "\x1b[38;2;0;128;0mname\x1b[0m\r\n\r\n\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
 }

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -145,6 +145,7 @@ func TestFormatterColorizer(t *testing.T) {
 	defer buf.Close()
 	s.vars.Set(SQLCMDCOLORSCHEME, "emacs")
 	s.Format.(*sqlCmdFormatterType).colorizer = color.New(true)
-	runSqlCmd(t, s, []string{"select 'name' as name", "GO"})
+	err := runSqlCmd(t, s, []string{"select 'name' as name", "GO"})
+	assert.NoError(t, err, "runSqlCmd returned error")
 	assert.Equal(t, "\x1b[38;2;0;128;0mname\x1b[0m"+SqlcmdEol+SqlcmdEol+"\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
 }

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/go-sqlcmd/internal/color"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -136,5 +137,14 @@ func BenchmarkDecodeBinary(b *testing.B) {
 			b.Fatalf("Incorrect length of returned string. Should be 20k, was %d", len(s))
 		}
 	}
+}
 
+func TestFormatterColorizer(t *testing.T) {
+
+	s, buf := setupSqlCmdWithMemoryOutput(t)
+	defer buf.Close()
+	s.vars.Set(SQLCMDCOLORSCHEME, "emacs")
+	s.Format.(*sqlCmdFormatterType).colorizer = color.New(true)
+	runSqlCmd(t, s, []string{"select 'name' as name", "GO"})
+	assert.Equal(t, "\x1b[38;5;2mname\x1b[0m"+SqlcmdEol+SqlcmdEol+"\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
 }

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang-sql/sqlexp"
 	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/microsoft/go-mssqldb/msdsn"
+	"github.com/microsoft/go-sqlcmd/internal/color"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -78,6 +79,7 @@ type Sqlcmd struct {
 	// PrintError allows the host to redirect errors away from the default output. Returns false if the error is not redirected by the host.
 	PrintError        func(msg string, severity uint8) bool
 	UnicodeOutputFile bool
+	colorizer         color.Colorizer
 }
 
 // New creates a new Sqlcmd instance
@@ -88,6 +90,7 @@ func New(l Console, workingDirectory string, vars *Variables) *Sqlcmd {
 		vars:             vars,
 		Cmd:              newCommands(),
 		Connect:          &ConnectSettings{},
+		colorizer:        color.New(false),
 	}
 	s.batch = NewBatch(s.scanNext, s.Cmd)
 	mssql.SetContextLogger(s)

--- a/pkg/sqlcmd/variables.go
+++ b/pkg/sqlcmd/variables.go
@@ -35,6 +35,7 @@ const (
 	SQLCMDMAXFIXEDTYPEWIDTH = "SQLCMDMAXFIXEDTYPEWIDTH"
 	SQLCMDEDITOR            = "SQLCMDEDITOR"
 	SQLCMDUSEAAD            = "SQLCMDUSEAAD"
+	SQLCMDCOLORSCHEME       = "SQLCMDCOLORSCHEME"
 )
 
 // builtinVariables are the predefined SQLCMD variables. Their values are printed first by :listvar
@@ -56,6 +57,7 @@ var builtinVariables = []string{
 	SQLCMDUSEAAD,
 	SQLCMDUSER,
 	SQLCMDWORKSTATION,
+	SQLCMDCOLORSCHEME,
 }
 
 // readonlyVariables are variables that can't be changed via :setvar
@@ -191,6 +193,11 @@ func (v Variables) TextEditor() string {
 	return v[SQLCMDEDITOR]
 }
 
+// ColorScheme is the name of the console output color scheme
+func (v Variables) ColorScheme() string {
+	return v[SQLCMDCOLORSCHEME]
+}
+
 func mustValue(val string) int64 {
 	var n int64
 	_, err := fmt.Sscanf(val, "%d", &n)
@@ -233,6 +240,7 @@ func InitializeVariables(fromEnvironment bool) *Variables {
 		SQLCMDSTATTIMEOUT:       defaultVariables[SQLCMDSTATTIMEOUT],
 		SQLCMDUSER:              "",
 		SQLCMDUSEAAD:            "",
+		SQLCMDCOLORSCHEME:       "",
 	}
 	hostname, _ := os.Hostname()
 	variables.Set(SQLCMDWORKSTATION, hostname)


### PR DESCRIPTION
- use `SQLCMDCOLORSCHEME` variable to identify the style/scheme name that matches one defined by the [chroma styles]<https://github.com/alecthomas/chroma/styles> package
- Add a `:list color` command to print samples of TSQL syntax in each scheme
- Colorizes query results and errors as well