### PR TITLE
Cope with no HOME env var in user shell

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	. "github.com/microsoft/go-sqlcmd/cmd/modern/sqlconfig"
 	"github.com/microsoft/go-sqlcmd/internal/io/file"
+	"github.com/microsoft/go-sqlcmd/internal/io/folder"
 	"github.com/microsoft/go-sqlcmd/internal/pal"
 	"os"
 	"path/filepath"
@@ -40,7 +41,14 @@ func SetFileNameForTest(t *testing.T) {
 // the user's home directory, the function will return an empty string.
 func DefaultFileName() (filename string) {
 	home, err := os.UserHomeDir()
-	checkErr(err)
+	if err != nil {
+		trace(
+			"Error getting user's home directory: %v, will use current directory %q as default",
+			err,
+			folder.Getwd(),
+		)
+		home = "."
+	}
 	filename = filepath.Join(home, ".sqlcmd", "sqlconfig")
 
 	return


### PR DESCRIPTION
It's possible for the user shell to have no $HOME/%USERPROFILE% env var. This closes #279.  We need to cope with this:

1. We will use "." (current working directory), as the default dir to place the .sqlcmd/sqlconfig file in, can be overriden using --sqlconfig (when in the modern CLI)
2. When running in legacy mode, we won't try to read the sqlconfig file if it doesn't exist in the default location (which requires the %HOME/%USERPROFILE% envvar), we also won't create an empty sqlconfig file in this case.