### PR TITLE
Pass --platform information into Container Create

### DIFF
--- a/cmd/modern/root/install/mssql-base.go
+++ b/cmd/modern/root/install/mssql-base.go
@@ -45,8 +45,10 @@ type MssqlBase struct {
 	defaultContextName     string
 	collation              string
 
-	name     string
-	hostname string
+	name         string
+	hostname     string
+	architecture string
+	os           string
 
 	port int
 
@@ -174,6 +176,20 @@ func (c *MssqlBase) AddFlags(
 	})
 
 	addFlag(cmdparser.FlagOptions{
+		String:        &c.architecture,
+		DefaultString: "amd64",
+		Name:          "architecture",
+		Usage:         "Specifies the image CPU architecture",
+	})
+
+	addFlag(cmdparser.FlagOptions{
+		String:        &c.os,
+		DefaultString: "linux",
+		Name:          "os",
+		Usage:         "Specifies the image operating system",
+	})
+
+	addFlag(cmdparser.FlagOptions{
 		String:        &c.collation,
 		DefaultString: "SQL_Latin1_General_CP1_CI_AS",
 		Name:          "collation",
@@ -272,6 +288,8 @@ func (c *MssqlBase) createContainer(imageName string, contextName string) {
 		c.port,
 		c.name,
 		c.hostname,
+		c.architecture,
+		c.os,
 		[]string{},
 		false,
 	)

--- a/internal/container/controller.go
+++ b/internal/container/controller.go
@@ -66,7 +66,17 @@ func (c Controller) EnsureImage(image string) (err error) {
 // ContainerRun creates a new container using the provided image and env values
 // and binds it to the specified port number. It then starts the container and returns
 // the ID of the container.
-func (c Controller) ContainerRun(image string, env []string, port int, name string, hostname string, architecture string, os string, command []string, unitTestFailure bool) string {
+func (c Controller) ContainerRun(
+	image string,
+	env []string,
+	port int,
+	name string,
+	hostname string,
+	architecture string,
+	os string,
+	command []string,
+	unitTestFailure bool,
+) string {
 	hostConfig := &container.HostConfig{
 		PortBindings: nat.PortMap{
 			nat.Port("1433/tcp"): []nat.PortBinding{
@@ -79,18 +89,17 @@ func (c Controller) ContainerRun(image string, env []string, port int, name stri
 	}
 
 	platform := specs.Platform{
-		Architecture: "AMD64",
-		OS:           "linux",
+		Architecture: architecture,
+		OS:           os,
 	}
 
 	resp, err := c.cli.ContainerCreate(context.Background(), &container.Config{
-		Tty:        true,
-		Image:      image,
-		Cmd:        command,
-		Env:        env,
-		Hostname:   hostname,
-		Domainname: name,
-	}, hostConfig, nil, &platform, "")
+		Tty:      true,
+		Image:    image,
+		Cmd:      command,
+		Env:      env,
+		Hostname: hostname,
+	}, hostConfig, nil, &platform, name)
 	checkErr(err)
 
 	err = c.cli.ContainerStart(

--- a/internal/container/controller_test.go
+++ b/internal/container/controller_test.go
@@ -33,7 +33,17 @@ func TestController_EnsureImage(t *testing.T) {
 	c := NewController()
 	err := c.EnsureImage(imageName)
 	checkErr(err)
-	id := c.ContainerRun(imageName, []string{}, port, "", "", []string{"ash", "-c", "echo 'Hello World'; sleep 3"}, false)
+	id := c.ContainerRun(
+		imageName,
+		[]string{},
+		port,
+		"",
+		"",
+		"amd64",
+		"linux",
+		[]string{"ash", "-c", "echo 'Hello World'; sleep 3"},
+		false,
+	)
 	c.ContainerRunning(id)
 	c.ContainerWaitForLogEntry(id, "Hello World")
 	c.ContainerExists(id)
@@ -76,6 +86,8 @@ func TestController_ContainerRunFailure(t *testing.T) {
 			0,
 			"",
 			"",
+			"amd64",
+			"linux",
 			[]string{"ash", "-c", "echo 'Hello World'; sleep 1"},
 			false,
 		)
@@ -102,6 +114,8 @@ func TestController_ContainerRunFailureCleanup(t *testing.T) {
 			0,
 			"",
 			"",
+			"amd64",
+			"linux",
 			[]string{"ash", "-c", "echo 'Hello World'; sleep 1"},
 			true,
 		)


### PR DESCRIPTION
Adds

      --architecture string             Specifies the image CPU architecture (default "amd64")
      --os string                       Specifies the image operating system (default "linux")

This should fix an issue on some Apple silicon machine (M1/M2) that seems to require these settings to be passed into the container create command

Closes #283 