### PR TITLE
Allow sqlcmd delete to succeed if container has already been deleted

### DIFF
--- a/cmd/modern/root/uninstall.go
+++ b/cmd/modern/root/uninstall.go
@@ -124,7 +124,7 @@ func (c *Uninstall) run() {
 				err = controller.ContainerRemove(id)
 				c.CheckErr(err)
 			} else {
-				output.Warnf("Container %s no longer exists, continuing to remove context...", id)
+				output.Warnf("Container %q no longer exists, continuing to remove context...", id)
 			}
 		}
 

--- a/cmd/modern/root/uninstall.go
+++ b/cmd/modern/root/uninstall.go
@@ -101,7 +101,7 @@ func (c *Uninstall) run() {
 					output.Fatal("Operation cancelled.")
 				}
 			}
-			if !c.force {
+			if controller.ContainerExists(id) && !c.force {
 				output.Infof("Verifying no user (non-system) database (.mdf) files")
 				if !controller.ContainerRunning(id) {
 					output.FatalfWithHintExamples([][]string{

--- a/cmd/modern/root/uninstall.go
+++ b/cmd/modern/root/uninstall.go
@@ -112,16 +112,20 @@ func (c *Uninstall) run() {
 				c.userDatabaseSafetyCheck(controller, id)
 			}
 
-			output.Infof(
-				"Stopping %s",
-				endpoint.ContainerDetails.Image,
-			)
-			err := controller.ContainerStop(id)
-			c.CheckErr(err)
-
 			output.Infof("Removing context %s", config.CurrentContextName())
-			err = controller.ContainerRemove(id)
-			c.CheckErr(err)
+
+			if controller.ContainerExists(id) {
+				output.Infof(
+					"Stopping %s",
+					endpoint.ContainerDetails.Image,
+				)
+				err := controller.ContainerStop(id)
+				c.CheckErr(err)
+				err = controller.ContainerRemove(id)
+				c.CheckErr(err)
+			} else {
+				output.Warnf("Container %s no longer exists, continuing to remove context...", id)
+			}
 		}
 
 		config.RemoveCurrentContext()


### PR DESCRIPTION
This PR allows the `sqlcmd delete` to succeed even if the user has manually deleted the container using something like `docker rm`.  sqlcmd will log a warning if it finds the container has already been removed, and will continue to delete the context (and endpoint/user) and will complete successfullly

Closes #282 