### PR TITLE
Add LICENSE/NOTICE.md to sqlcmd install folder

### DIFF
--- a/.pipelines/include-install-go-tools.yml
+++ b/.pipelines/include-install-go-tools.yml
@@ -8,8 +8,7 @@ steps:
       command: 'get'
       arguments: '-d'
       workingDirectory: '$(Build.SourcesDirectory)/cmd/sqlcmd'
-  
-  
+
   - task: Go@0
     displayName: 'Go: install gotest.tools/gotestsum'
     inputs:

--- a/build/azure-pipelines/build-common.yml
+++ b/build/azure-pipelines/build-common.yml
@@ -4,7 +4,6 @@ parameters:
   default:
 - name: Arch
   type: string
-  default: 
 - name: ArtifactName
   type: string
 - name: VersionTag

--- a/build/azure-pipelines/build-product.yml
+++ b/build/azure-pipelines/build-product.yml
@@ -20,56 +20,56 @@ stages:
         matrix:
           linux:
             imageName: 'ubuntu-latest'
-            artifact: LinuxAmd64
+            artifact: Linux-amd64
             os:
             arch:
             binaryName: 'sqlcmd'
             binaryExt: ''
           mac:
             imageName: 'macOS-latest'
-            artifact: DarwinAmd64
+            artifact: Darwin-x64
             os:
             arch:
             binaryName: 'sqlcmd'
             binaryExt: ''
           macArm:
             imageName: 'macOS-latest'
-            artifact: DarwinArm64
+            artifact: Darwin-arm64
             os:
             arch: arm64
             binaryName: 'sqlcmd'
             binaryExt: ''
           windows:
             imageName: 'windows-latest'
-            artifact: WindowsAmd64
+            artifact: Windows-x64
             os:
             arch:
             binaryName: 'sqlcmd'
             binaryExt: '.exe'
           linuxArm:
             imageName: 'ubuntu-latest'
-            artifact: LinuxArm64
+            artifact: Linux-arm64
             os:
             arch: arm64
             binaryName: 'sqlcmd'
             binaryExt: ''
           windowsArm:
            imageName: 'windows-latest'
-           artifact: WindowsArm
+           artifact: Windows-arm
            os:
            arch: arm
            binaryName: 'sqlcmd'
            binaryExt: '.exe'
           windowsArm64:
             imageName: 'windows-latest'
-            artifact: WindowsArm64
+            artifact: Windows-arm64
             os:
             arch: arm64
             binaryName: 'sqlcmd'
             binaryExt: '.exe'
           linuxs390x:
             imageName: 'ubuntu-latest'
-            artifact: LinuxS390x
+            artifact: Linux-s390x
             os:
             arch: s390x
             binaryName: 'sqlcmd'
@@ -154,9 +154,9 @@ stages:
           MaxConcurrency: '50'
           MaxRetryAttempts: '5'
       - task: ArchiveFiles@2
-        displayName: Zip Windows amd64 binary
+        displayName: Zip Windows x64 binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsAmd64'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindows-x64'
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-x64.zip'
@@ -164,7 +164,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Zip Windows arm binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindows-arm'
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm.zip'
@@ -172,7 +172,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Zip Windows arm64 binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindowsArm64'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdWindows-arm64'
           includeRootFolder: false
           archiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-windows-arm64.zip'
@@ -180,25 +180,25 @@ stages:
       - task: ArchiveFiles@2
         displayName: Tar Linux amd64 binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdLinuxAmd64'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdLinux-amd64'
           includeRootFolder: false
           archiveType: 'tar'
           tarCompression: 'bz2'
-          archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-linux-x64.tar.bz2'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-linux-amd64.tar.bz2'
 
       - task: ArchiveFiles@2
         displayName: Tar Darwin binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdDarwinAmd64'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdDarwin-x64'
           includeRootFolder: false
           archiveType: 'tar'
           tarCompression: 'bz2'
           archiveFile: '$(Build.ArtifactStagingDirectory)/sqlcmd-$(getVersion.VERSION_TAG)-darwin-x64.tar.bz2'
 
       - task: ArchiveFiles@2
-        displayName: Tar Darwin Arm binary
+        displayName: Tar Darwin arm binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdDarwinArm64'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdDarwin-arm64'
           includeRootFolder: false
           archiveType: 'tar'
           tarCompression: 'bz2'
@@ -207,7 +207,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Tar Linux arm64 binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdLinuxArm64'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdLinux-arm64'
           includeRootFolder: false
           archiveType: 'tar'
           tarCompression: 'bz2'
@@ -216,7 +216,7 @@ stages:
       - task: ArchiveFiles@2
         displayName: Tar Linux s390x binary
         inputs:
-          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdLinuxS390x'
+          rootFolderOrFile: '$(Pipeline.Workspace)\SqlcmdLinux-s390x'
           includeRootFolder: false
           archiveType: 'tar'
           tarCompression: 'bz2'

--- a/build/azure-pipelines/package-common-create.yml
+++ b/build/azure-pipelines/package-common-create.yml
@@ -2,6 +2,8 @@ parameters:
 - name: OS
   type: string
   default:
+- name: Architecture
+  type: string
 - name: Type
   type: string
 
@@ -41,6 +43,7 @@ steps:
     msbuildArgs: '/p:Configuration=Release'
   env:
     CLI_VERSION: $(VERSION_TAG)
+    ARCHITECTURE: ${{ parameters.Architecture }}
 - task: EsrpCodeSigning@2
   condition: eq(variables.OS, 'windows')
   inputs:
@@ -100,7 +103,7 @@ steps:
   inputs:
    targetType: 'inline'
    script: |
-      mv "$(Build.SourcesDirectory)/release/windows/msi/bin/Release/sqlcmd.msi" "$(Build.SourcesDirectory)/release/windows/msi/bin/Release/sqlcmd_${CLI_VERSION}-${CLI_VERSION_REVISION}.msi"
+      mv "$(Build.SourcesDirectory)/release/windows/msi/bin/Release/sqlcmd.msi" "$(Build.SourcesDirectory)/release/windows/msi/bin/Release/sqlcmd-${{ parameters.ARCHITECTURE }}_${CLI_VERSION}-${CLI_VERSION_REVISION}.msi"
   env:
     CLI_VERSION: $(VERSION_TAG)
     CLI_VERSION_REVISION: 1
@@ -132,7 +135,7 @@ steps:
     MaxConcurrency: '50'
     MaxRetryAttempts: '20'
 - task: PublishPipelineArtifact@0
-  displayName: 'Publish Artifact: ${{ parameters.Type }}'
+  displayName: 'Publish Artifact: ${{ parameters.Type }} ${{ parameters.Architecture }}'
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)
-    artifactName: ${{ parameters.Type }}
+    artifactName: ${{ parameters.Type }} ${{ parameters.Architecture }}

--- a/build/azure-pipelines/package-common-test.yml
+++ b/build/azure-pipelines/package-common-test.yml
@@ -2,6 +2,8 @@ parameters:
 - name: OS
   type: string
   default:
+- name: Architecture
+  type: string
 - name: Type
   type: string
 
@@ -25,12 +27,17 @@ steps:
     CLI_VERSION: $(VERSION_TAG)
     BUILD_STAGINGDIRECTORY: $(Build.ArtifactStagingDirectory)
 - task: PowerShell@2
-  condition: eq(variables.OS, 'windows')
-  displayName: 'Test ${{ parameters.OS }}/${{ parameters.Type }} package'
+
+  # Windows ARM not available in ADO pipelines yet, so only test on Amd64
+  # https://learn.microsoft.com/azure/devops/pipelines/agents/hosted
+  # https://github.com/microsoft/azure-pipelines-agent/issues/3935
+  condition: and(eq(variables.OS, 'windows'), eq(variables.Architecture, 'x64'))
+  displayName: 'Test ${{ parameters.OS }}/${{ parameters.Architecture }}/${{ parameters.Type }} package'
   inputs:
     targetType: 'filePath'
     filePath: '$(Build.SourcesDirectory)\release\windows\msi\scripts\pipeline-test.ps1'
     failOnStderr: true
   env:
     CLI_VERSION: $(VERSION_TAG)
+    ARCHITECTURE: ${{ parameters.Architecture }}
     

--- a/build/azure-pipelines/package-product.yml
+++ b/build/azure-pipelines/package-product.yml
@@ -19,17 +19,31 @@ stages:
             imageName: 'ubuntu-latest'
             os: linux
             type: rpm
+            architecture: x86_x64
           debian:
             imageName: 'ubuntu-latest'
             os: linux
             type: deb
+            architecture: amd64
           docker:
             imageName: 'ubuntu-latest'
             os: linux
             type: docker
-          windows:
+            architecture: amd64
+          windows-x64:
             imageName: 'windows-2019'
             os: windows
+            architecture: x64
+            type: msi
+          windows-arm:
+            imageName: 'windows-2019'
+            os: windows
+            architecture: arm
+            type: msi
+          windows-arm64:
+            imageName: 'windows-2019'
+            os: windows
+            architecture: arm64
             type: msi
       pool:
         vmImage: $(imageName)
@@ -37,8 +51,10 @@ stages:
         - template: package-common-create.yml
           parameters:
             OS: $(os)
+            Architecture: $(architecture)
             Type: $(type)
         - template: package-common-test.yml
           parameters:
             OS: $(os)
+            Architecture: $(architecture)
             Type: $(type)

--- a/release/linux/deb/pipeline.sh
+++ b/release/linux/deb/pipeline.sh
@@ -46,7 +46,7 @@ DIST_DIR=${BUILD_STAGINGDIRECTORY:=${REPO_ROOT_DIR}/output/debian}
 PIPELINE_WORKSPACE=${REPO_ROOT_DIR}
 
 if [[ "${BUILD_OUTPUT}" != "" ]]; then
-    cp ${BUILD_OUTPUT}/SqlcmdLinuxAmd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
+    cp ${BUILD_OUTPUT}/SqlcmdLinux-amd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
 fi
 
 CLI_VERSION=${CLI_VERSION:=0.0.1}

--- a/release/linux/docker/pipeline.sh
+++ b/release/linux/docker/pipeline.sh
@@ -22,7 +22,7 @@ DIST_DIR=${BUILD_STAGINGDIRECTORY:=${REPO_ROOT_DIR}/output/docker}
 IMAGE_NAME=microsoft/sqlcmd${BUILD_BUILDNUMBER:=''}
 
 if [[ "${BUILD_OUTPUT}" != "" ]]; then
-    cp ${BUILD_OUTPUT}/SqlcmdLinuxAmd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
+    cp ${BUILD_OUTPUT}/SqlcmdLinux-amd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
 fi
 
 chmod u+x ${REPO_ROOT_DIR}/sqlcmd

--- a/release/linux/rpm/pipeline.sh
+++ b/release/linux/rpm/pipeline.sh
@@ -22,7 +22,7 @@ set -exv
 : "${REPO_ROOT_DIR:=`cd $(dirname $0); cd ../../../; pwd`}"
 
 if [[ "${BUILD_OUTPUT}" != "" ]]; then
-    cp ${BUILD_OUTPUT}/SqlcmdLinuxAmd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
+    cp ${BUILD_OUTPUT}/SqlcmdLinux-amd64/sqlcmd ${REPO_ROOT_DIR}/sqlcmd
 fi
 
 DIST_DIR=${BUILD_STAGINGDIRECTORY:=${REPO_ROOT_DIR}/output/rpm}

--- a/release/windows/msi/product.wxs
+++ b/release/windows/msi/product.wxs
@@ -44,15 +44,11 @@
         <Directory Id="SqlcmdDirectory" Name="$(var.AppName)">
           <Component Id="sqlcmd.exe" Guid="2988854C-D02C-4D48-866C-8EAEBA6BC54B">
             <CreateFolder />
-            <RemoveFolder Id="RemoveSqlCmdDirectory" On="uninstall" />
-            <RegistryKey Root="HKCU" Key="Software\Microsoft\SqlCmd">
-              <RegistryValue Name="MainExe" Value="1" KeyPath="yes" Type="integer" />
-            </RegistryKey>
+            <RemoveFolder Id="RemoveFolder" On="uninstall" />
             <File
               Id="sqlcmd.exe"
               Name="sqlcmd.exe"
-              Source="$(env.PIPELINE_WORKSPACE)\SqlcmdWindowsAmd64\sqlcmd.exe"
-              DiskId="1"
+              Source="$(env.PIPELINE_WORKSPACE)\SqlcmdWindows-$(env.ARCHITECTURE)\sqlcmd.exe"
               Checksum="yes"/>
             <Environment
               Id="PATH"
@@ -63,6 +59,20 @@
               Action="set"
               System="yes" />
           </Component>
+          <Component Id="notice" Guid="9BB06B71-91BF-4431-B88D-C7E4BCA1F435">
+            <File
+              Id="NOTICE.md"
+              Name="NOTICE.md"
+              Source="$(env.PIPELINE_WORKSPACE)\SqlcmdWindows-$(env.ARCHITECTURE)\NOTICE.md"
+              Checksum="no"/>
+          </Component>
+         <Component Id="license" Guid="F9E6D3F8-8B09-49C6-8309-74F88DD765B0">
+            <File
+              Id="LICENSE"
+              Name="LICENSE"
+              Source="$(env.PIPELINE_WORKSPACE)\s\LICENSE"
+              Checksum="no"/>
+          </Component>
         </Directory>
       </Directory>
     </Directory>
@@ -71,7 +81,8 @@
              Level="1"
              AllowAdvertise="no">
       <ComponentRef Id="sqlcmd.exe" />
+      <ComponentRef Id="notice" />
+      <ComponentRef Id="license" />
     </Feature>
-
   </Product>
 </Wix>

--- a/release/windows/msi/scripts/pipeline-test.ps1
+++ b/release/windows/msi/scripts/pipeline-test.ps1
@@ -16,10 +16,11 @@
 
 if (-not (Test-Path env:CLI_VERSION)) { $env:CLI_VERSION = '0.0.1' }
 if (-not (Test-Path env:CLI_VERSION_REVISION)) { $env:CLI_VERSION_REVISION = '1' }
+if (-not (Test-Path env:ARCHITECTURE)) { $env:ARCHITECTURE = 'amd64' }
 
 tree /A /F $env:SYSTEM_ARTIFACTSDIRECTORY
 
-$msiPath = Join-Path $env:SYSTEM_ARTIFACTSDIRECTORY ("sqlcmd_" + $env:CLI_VERSION + "-" + $env:CLI_VERSION_REVISION + ".msi")
+$msiPath = Join-Path $env:SYSTEM_ARTIFACTSDIRECTORY ("sqlcmd-" + $env:ARCHITECTURE + "_" + $env:CLI_VERSION + "-" + $env:CLI_VERSION_REVISION + ".msi")
 
 $msiPath
 

--- a/release/windows/msi/scripts/pipeline.cmd
+++ b/release/windows/msi/scripts/pipeline.cmd
@@ -29,9 +29,9 @@ set REPO_ROOT=%~dp0..\..\..\..
 
 set PIPELINE_WORKSPACE=%ARTIFACTS_DIR%\workspace
 
-mkdir %PIPELINE_WORKSPACE%\SqlcmdWindowsAmd64
+mkdir %PIPELINE_WORKSPACE%\SqlcmdWindows-%ARCHITECTURE%
 
-copy /y %REPO_ROOT%\sqlcmd.exe %PIPELINE_WORKSPACE%\SqlcmdWindowsAmd64\sqlcmd.exe
+copy /y %REPO_ROOT%\sqlcmd.exe %PIPELINE_WORKSPACE%\SqlcmdWindows-%ARCHITECTURE%\sqlcmd.exe
 
 ::ensure wix is available
 if exist %WIX_DIR% (


### PR DESCRIPTION
1. Add LICENSE/NOTICE.md to the install directory on Windows .msi installs (winget/choco)
2. Add arm/arm64 .msi builds (a separate winget repo PR adds these to the winget installer)
3. Also, align Architecture naming to winget/brew/debian:

So we will have:

x64 (for Windows/Mac)
amd64 (for Linux)

x86 (for Windows/Mac)
arm (for all Platforms)
arm64 (for all Platforms)

Sources:

https://github.com/jedieaston/winget-cli/blob/0384fcd3657942f59bc94aae3dd888742f9ef632/schemas/JSON/settings/settings.schema.0.2.json#L58

            "enum": [
              "neutral",
              "x64",
              "x86",
              "arm64",
              "arm"
            ],

This also seems to be align with brew:

https://github.com/Homebrew/homebrew-core/blob/361429d75bf64c698c3d971f7aeebe01cedb87c2/Formula/sqlcmd.rb

    sha256 cellar: :any_skip_relocation, arm64_ventura:  
    sha256 cellar: :any_skip_relocation, arm64_monterey:
    sha256 cellar: :any_skip_relocation, arm64_big_sur:  
    sha256 cellar: :any_skip_relocation, ventura:        
    sha256 cellar: :any_skip_relocation, monterey:       
    sha256 cellar: :any_skip_relocation, big_sur:        
    sha256 cellar: :any_skip_relocation, x86_64_linux:   
    
For Debian installers, the choices are:

Available options: amd64,arm64,armel,armhf,i386,mips,mips64el,mipsel,ppc64el,s390x