### PR TITLE
Cope with old sqlconfig files wrt --password-encrypted flag

### DIFF
--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -46,6 +46,13 @@ func Decode(cipherText string, passwordEncryption string) (plainText string) {
 	if cipherText == "" {
 		panic("Cannot decode/decrypt an empty string")
 	}
+
+	// BUG(stuartpa): Temporary code, remove when rolling over to v1.0.0, needed
+	// as very early users migrated from the old password-encrypted bool value
+	if passwordEncryption == "" {
+		passwordEncryption = "none"
+	}
+
 	if !IsValidEncryptionMethod(passwordEncryption) {
 		panic(fmt.Sprintf(
 			"Invalid encryption method (%q not in %q)",


### PR DESCRIPTION
I missed committing this file in the previous PR, so testing I did with old sqlconfig files passed locally.  I've added a note to the release note for the .3 release, for how end users can edit their old sqlconfig.

Longer term we need to move to proper versioning of schema changes in sqlconfig (although I see kubeconfig is still at v1)