### PR TITLE
Update NOTICE and a test

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -556,8 +556,8 @@ Apache License
 ## github.com/docker/docker
 
 * Name: github.com/docker/docker
-* Version: v20.10.21
-* License: [Apache-2.0](https://github.com/docker/docker/blob/v20.10.21/LICENSE)
+* Version: v20.10.24
+* License: [Apache-2.0](https://github.com/docker/docker/blob/v20.10.24/LICENSE)
 
 ```
 

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -289,7 +289,7 @@ func TestExitCodeSetOnError(t *testing.T) {
 	assert.Equal(t, -101, retcode, "ExitOnError and ErrorSeverityLevel = 0, Raiserror below 10")
 	retcode, err = s.runQuery("RAISERROR (15002, 10, 127, 'param')")
 	assert.ErrorIs(t, err, ErrExitRequested, "RAISERROR with state 127")
-	assert.Equal(t, 15001, retcode, "RAISERROR (15002, 10, 127, 'param')")
+	assert.Equal(t, 15002, retcode, "RAISERROR (15002, 10, 127, 'param')")
 }
 
 func TestSqlCmdExitOnError(t *testing.T) {

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -287,9 +287,9 @@ func TestExitCodeSetOnError(t *testing.T) {
 	retcode, err = s.runQuery("RAISERROR (N'Testing!' , 5, 1)")
 	assert.NoError(t, err, "ExitOnError and ErrorSeverityLevel = 0, Raiserror below 10")
 	assert.Equal(t, -101, retcode, "ExitOnError and ErrorSeverityLevel = 0, Raiserror below 10")
-	retcode, err = s.runQuery("RAISERROR (15001, 10, 127)")
+	retcode, err = s.runQuery("RAISERROR (15002, 10, 127, 'param')")
 	assert.ErrorIs(t, err, ErrExitRequested, "RAISERROR with state 127")
-	assert.Equal(t, 15001, retcode, "RAISERROR (15001, 10, 127)")
+	assert.Equal(t, 15001, retcode, "RAISERROR (15002, 10, 127, 'param')")
 }
 
 func TestSqlCmdExitOnError(t *testing.T) {


### PR DESCRIPTION
Error `15001` was a bad choice because until recently it had an incorrect format specifier for its parameter. That specifier has been fixed in Azure SQL Database so it can only be raised with a proper parameter. Switching to `15002` with a valid parameter to pass on all editions.