### PR TITLE
implement :xml

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -30,6 +30,8 @@ const (
 	TextTypeError
 	// TextTypeWarning is for warning messages
 	TextTypeWarning
+	// TextTypeXml indicates the content is XML
+	TextTypeXml
 )
 
 var typeMap map[TextType]chroma.TokenType = map[TextType]chroma.TokenType{
@@ -83,6 +85,10 @@ func (c *chromaColorizer) Write(w io.Writer, s string, scheme string, t TextType
 		_, err = w.Write([]byte(s))
 	case TextTypeTSql:
 		if err = quick.Highlight(w, s, "transact-sql", "terminal16m", scheme); err != nil {
+			_, err = w.Write([]byte(s))
+		}
+	case TextTypeXml:
+		if err = quick.Highlight(w, s, "xml", "terminal16m", scheme); err != nil {
 			_, err = w.Write([]byte(s))
 		}
 	default:

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -54,6 +54,11 @@ func TestWrite(t *testing.T) {
 			args:  args{s: "warn", t: TextTypeWarning},
 			wantW: "\x1b[3mwarn\x1b[0m",
 		},
+		{
+			name:  "XML",
+			args:  args{s: "<node>value</node>", t: TextTypeXml},
+			wantW: "\x1b[1m\x1b[38;2;0;128;0m<node>\x1b[0mvalue\x1b[1m\x1b[38;2;0;128;0m</node>\x1b[0m",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sqlcmd/commands_test.go
+++ b/pkg/sqlcmd/commands_test.go
@@ -51,6 +51,7 @@ func TestCommandParsing(t *testing.T) {
 		{`:!!notepad`, "EXEC", []string{"notepad"}},
 		{` !! dir c:\`, "EXEC", []string{` dir c:\`}},
 		{`!!dir c:\`, "EXEC", []string{`dir c:\`}},
+		{`:XML ON `, "XML", []string{`ON `}},
 	}
 
 	for _, test := range commands {

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -149,3 +149,12 @@ func TestFormatterColorizer(t *testing.T) {
 	assert.NoError(t, err, "runSqlCmd returned error")
 	assert.Equal(t, "\x1b[38;2;0;128;0mname\x1b[0m"+SqlcmdEol+SqlcmdEol+"\x1b[3m(1 row affected)"+SqlcmdEol+"\x1b[0m", buf.buf.String())
 }
+
+func TestFormatterXmlMode(t *testing.T) {
+	s, buf := setupSqlCmdWithMemoryOutput(t)
+	defer buf.Close()
+	s.Format.XmlMode(true)
+	err := runSqlCmd(t, s, []string{"select name from sys.databases where name='master' for xml auto ", "GO"})
+	assert.NoError(t, err, "runSqlCmd returned error")
+	assert.Equal(t, `<sys.databases name="master"/>`+SqlcmdEol, buf.buf.String())
+}


### PR DESCRIPTION
Fixes #335 
Of course it supports color!

```
1> :setvar sqlcmdcolorscheme github-dark
1> select cast((select name, containment, is_ledger_on from sys.databases for xml auto) AS VARCHAR(MAX)) AS XmlData
2> go
```

![image](https://github.com/microsoft/go-sqlcmd/assets/2224906/7e5bf76b-1dc0-4b5b-a6bd-89afda1cefc6)
