### PR TITLE
Do not read basic auth info if auth type is other

### DIFF
--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -101,7 +101,7 @@ func CurrentContext() (endpoint Endpoint, user *User) {
 func GetCurrentContextInfo() (server string, username string, password string) {
 	endpoint, user := CurrentContext()
 	server = fmt.Sprintf("%s,%d", endpoint.Address, endpoint.Port)
-	if user != nil {
+	if user != nil && user.AuthenticationType == "basic" {
 		username = user.BasicAuth.Username
 		if user.AuthenticationType == "basic" {
 			password = decryptCallback(


### PR DESCRIPTION
This commit fixes #339 
`sqlcmd config add-user` command by default assumes basic authentication type but in case a user is created with auth type other than "basic" then connection will be established to endpoint mentioned by current-context (which is existing behavior) and further auth info won't be read as auth type "other" is not supported yet.