### PR TITLE
removing extra error and usage print

### DIFF
--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -126,9 +126,11 @@ func Execute(version string) {
 		PreRunE: func(cmd *cobra.Command, argss []string) error {
 			SetScreenWidthFlag(&args, cmd)
 			if err := args.Validate(); err != nil {
+				cmd.SilenceUsage = true
 				return err
 			}
 			if err := normalizeFlags(cmd); err != nil {
+				cmd.SilenceUsage = true
 				return err
 			}
 			return nil
@@ -158,14 +160,6 @@ func Execute(version string) {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-}
-
-func normalizeWithError(name string, err error) (pflag.NormalizedName, error) {
-	//checking nil
-	if name != "" && err != nil {
-		return "", localizer.Errorf("%s", err)
-	}
-	return pflag.NormalizedName(name), nil
 }
 
 func SetScreenWidthFlag(args *SQLCmdArguments, rootCmd *cobra.Command) {
@@ -248,10 +242,7 @@ func normalizeFlags(rootCmd *cobra.Command) error {
 			case "default", "readonly":
 				return pflag.NormalizedName(name)
 			default:
-				_, err = normalizeWithError(value, fmt.Errorf("--application-intent must be one of \"default\",\"readonly\" but got \"%s\"", value))
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-				}
+				err = fmt.Errorf("--application-intent must be one of \"default\",\"readonly\" but got \"%s\"", value)
 				return pflag.NormalizedName("")
 			}
 		case "encrypt-connection":
@@ -260,10 +251,7 @@ func normalizeFlags(rootCmd *cobra.Command) error {
 			case "default", "false", "true", "disable":
 				return pflag.NormalizedName(name)
 			default:
-				_, err = normalizeWithError(value, fmt.Errorf("--encrypt-connection must be one of \"default\",\"false\",\"true\",\"disable\" but got \"%s\"", value))
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-				}
+				err = fmt.Errorf("--encrypt-connection must be one of \"default\",\"false\",\"true\",\"disable\" but got \"%s\"", value)
 				return pflag.NormalizedName("")
 			}
 		case "format":
@@ -272,10 +260,7 @@ func normalizeFlags(rootCmd *cobra.Command) error {
 			case "horiz", "horizontal", "vert", "vertical":
 				return pflag.NormalizedName(name)
 			default:
-				_, err = normalizeWithError(value, fmt.Errorf("--format must be one of \"horiz\",\"horizontal\",\"vert\",\"vertical\" but got \"%s\"", value))
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-				}
+				err = fmt.Errorf("--format must be one of \"horiz\",\"horizontal\",\"vert\",\"vertical\" but got \"%s\"", value)
 				return pflag.NormalizedName("")
 			}
 		case "errors-to-stderr":
@@ -284,10 +269,7 @@ func normalizeFlags(rootCmd *cobra.Command) error {
 			case "-1", "0", "1":
 				return pflag.NormalizedName(name)
 			default:
-				_, err = normalizeWithError(value, fmt.Errorf("--errors-to-stderr must be one of \"-1\",\"0\",\"1\" but got \"%s\"", value))
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-				}
+				err = fmt.Errorf("--errors-to-stderr must be one of \"-1\",\"0\",\"1\" but got \"%s\"", value)
 				return pflag.NormalizedName("")
 			}
 		}

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -137,7 +137,7 @@ func Execute(version string) {
 		},
 		Run: func(cmd *cobra.Command, argss []string) {
 			if len(argss) > 0 {
-				fmt.Printf("Sqlcmd: '%s': Unknown Option. Enter '-?' for help.", argss[0])
+				fmt.Printf("Sqlcmd: '%s': Unknown command. Enter '--help' for command help.", argss[0])
 				os.Exit(1)
 			}
 
@@ -161,29 +161,6 @@ func Execute(version string) {
 
 		},
 	}
-
-	// rootCmd.SetUsageTemplate(`
-	// Usage:{{if .Runnable}}
-	//   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-	//   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-	// Aliases:
-	//   {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-	// Examples:
-	// {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
-
-	// Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-	//   {{rpad .Name .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-	// Flags:{{.LocalFlagsIndented}}{{end}}{{if .HasAvailableInheritedFlags}}
-
-	// Global Flags:{{.InheritedFlagsIndented}}{{end}}{{if .HasHelpSubCommands}}
-
-	// Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
-	//   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}
-	// `)
-
 	setFlags(rootCmd, &args)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -136,6 +136,11 @@ func Execute(version string) {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, argss []string) {
+			if len(argss) > 0 {
+				fmt.Printf("Sqlcmd: '%s': Unknown Option. Enter '-?' for help.", argss[0])
+				os.Exit(1)
+			}
+
 			vars := sqlcmd.InitializeVariables(!args.DisableCmdAndWarn)
 			setVars(vars, &args)
 
@@ -156,6 +161,29 @@ func Execute(version string) {
 
 		},
 	}
+
+	// rootCmd.SetUsageTemplate(`
+	// Usage:{{if .Runnable}}
+	//   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+	//   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+	// Aliases:
+	//   {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+	// Examples:
+	// {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+	// Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+	//   {{rpad .Name .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+	// Flags:{{.LocalFlagsIndented}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+	// Global Flags:{{.InheritedFlagsIndented}}{{end}}{{if .HasHelpSubCommands}}
+
+	// Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+	//   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}
+	// `)
+
 	setFlags(rootCmd, &args)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Related to issue : https://github.com/microsoft/go-sqlcmd/issues/343
Removed Extra error commands and usage print.

Before PR changes :
C:\src\go-sqlcmd\cmd\modern>sqlcmd --encrypt-connection yes
--encrypt-connection must be one of "default","false","true","disable" but got "yes"
Error: --encrypt-connection must be one of "default","false","true","disable" but got "yes"
Usage:
   [flags]

 

Flags:
  -N, -- string                         This switch is used by the client to request an encrypted connection. (default "default")
  -K, --application-intent string       Declares the application workload type when connecting to a server. The only currently supported value is ReadOnly. If -K is not specified, the sqlcmd utility will not support connectivity to a secondary replica in an Always On availability group (default "default")
      --authentication-method string    Specifies the SQL authentication method to use to connect to Azure SQL Database. One of:ActiveDirectoryDefault,ActiveDirectoryIntegrated,ActiveDirectoryPassword,ActiveDirectoryInteractive,ActiveDirectoryManagedIdentity,ActiveDirectoryServicePrincipal,SqlPassword
  -c, --batch-terminator string         Specifies the batch terminator. The default value is GO (default "GO")
  -s, --column-separator string         Specifies the column separator character. Sets the SQLCMDCOLSEP variable.
  -d, --database-name string            This option sets the sqlcmd scripting variable SQLCMDDBNAME. This parameter specifies the initial database. The default is your login's default-database property. If the database does not exist, an error message is generated and sqlcmd exits.
  -X, --disable-cmd-and-warn            Disables commands that might compromise system security. Sqlcmd issues a warning and continues.
  -x, --disable-variable-substitution   Causes sqlcmd to ignore scripting variables. This parameter is useful when a script contains many INSERT statements that may contain strings that have the same format as regular variables, such as $(variable_name).
      --driver-logging-level int        Level of mssql driver messages to print.
  -m, --error-level int                 Controls which error messages are sent to stdout. Messages that have severity level greater than or equal to this level are sent.
  -V, --error-severity-level uint8      Controls the severity level that is used to set the ERRORLEVEL variable on exit.
  -r, --errors-to-stderr int            Controls which error messages are sent to stdout. Messages that have severity level greater than or equal to this level are sent. (default -1)
  -b, --exit-on-error                   Specifies that sqlcmd exits and returns a DOS ERRORLEVEL value when an error occurs.
  -F, --format string                   Specifies the formatting for results. (default "horiz")
  -h, --headers int                     Specifies the number of rows to print between the column headings. Use -h-1 to specify that headers not be printed.
  -?, --help                            Show syntax summary.
  -q, --initial-query string            Executes a query when sqlcmd starts, but does not exit sqlcmd when the query has finished running. Multiple-semicolon-delimited queries can be executed.
  -i, --input-file strings              Identifies one or more files that contain batches of SQL statements. If one or more files do not exist, sqlcmd will exit. Mutually exclusive with -Q/-q.
  -l, --login-timeOut int               Specifies the number of seconds before a sqlcmd login to the go-mssqldb driver times out when you try to connect to a server. This option sets the sqlcmd scripting variable SQLCMDLOGINTIMEOUT. The default value is 30. 0 means infinite. (default -1)
  -M, --multi-subnet-failover           Provided for backward compatibility. Sqlcmd always optimizes detection of the active replica of a SQL Failover Cluster.
  -o, --output-file string              Identifies the file that receives output from sqlcmd.
  -a, --packet-size int                 Requests a packet of a different size. This option sets the sqlcmd scripting variable SQLCMDPACKETSIZE. packet_size must be a value between 512 and 32767. The default = 4096. A larger packet size can enhance performance for execution of scripts that have lots of SQL statements between GO commands. You can request a larger packet size. However, if the request is denied, sqlcmd uses the server default for packet size.
  -P, --password string                 Obsolete. The initial passwords must be set using the SQLCMDPASSWORD environment variable or entered at the password prompt.
  -Q, --query string                    Executes a query when sqlcmd starts and then immediately exits sqlcmd. Multiple-semicolon-delimited queries can be executed.
      --screen-width int                Specifies the screen width for output
  -S, --server string                   [[tcp:]|[lpc:]|[np:]]server[\instance_name][,port]Specifies the instance of SQL Server to which to connect. It sets the sqlcmd scripting variable SQLCMDSERVER.
  -W, --trim-spaces                     Remove trailing spaces from a column.
  -C, --trust-server-certificate        Implicitly trust the server certificate without validation.
  -u, --unicode-output-file             Specifies that all output files are encoded with little-endian Unicode
  -G, --use-aad                         Tells sqlcmd to use Active Directory authentication. If no user name is provided, authentication method ActiveDirectoryDefault is used. If a password is provided, ActiveDirectoryPassword is used. Otherwise ActiveDirectoryInteractive is used.
  -E, --use-trusted-connection          Uses a trusted connection instead of using a user name and password to sign in to SQL Server, ignoring any environment variables that define user name and password.
  -U, --user-name string                The login name or contained database user name.  For contained database users, you must provide the database name option
  -v, --variables stringToString        Creates a sqlcmd scripting variable that can be used in a sqlcmd script. Enclose the value in quotation marks if the value contains spaces. You can specify multiple var=values values. If there are errors in any of the values specified, sqlcmd generates an error message and then exits (default [])
      --version                         Print version information and exit
  -w, --w int                           Specifies the screen width for output
  -H, --workstation-name string         This option sets the sqlcmd scripting variable SQLCMDWORKSTATION. The workstation name is listed in the hostname column of the sys.sysprocesses catalog view and can be returned using the stored procedure sp_who. If this option is not specified, the default is the current computer name. This name can be used to identify different sqlcmd sessions.
  
  
  After PR changes :
  
 .\sqlcmd.exe --encrypt-connection yes
Error: --encrypt-connection must be one of "default","false","true","disable" but got "yes"
  