### PR TITLE
Mark release as pre-release

### DIFF
--- a/build/azure-pipelines/build-product.yml
+++ b/build/azure-pipelines/build-product.yml
@@ -239,3 +239,4 @@ stages:
           tag: '$(getVersion.VERSION_TAG)'
           changeLogCompareToRelease: 'lastFullRelease'
           changeLogType: 'commitBased'
+          isPreRelease: true


### PR DESCRIPTION
Fixes #351
Releases via build pipeline will now be published as pre-release.