### PR TITLE
fix: use TCP as default protocol

### DIFF
--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -26,9 +26,6 @@ import (
 	"golang.org/x/text/transform"
 )
 
-// Note: The order of includes above matters for namedpipe and sharedmemory.
-// init() swaps shared memory protocol with tcp so it gets priority when dialing.
-
 var (
 	// ErrExitRequested tells the hosting application to exit immediately
 	ErrExitRequested = errors.New("exit")

--- a/pkg/sqlcmd/sqlcmd_test.go
+++ b/pkg/sqlcmd/sqlcmd_test.go
@@ -644,9 +644,9 @@ func TestSqlcmdPrefersSharedMemoryProtocol(t *testing.T) {
 	if runtime.GOOS != "windows" || runtime.GOARCH != "amd64" {
 		t.Skip("Only valid on Windows amd64")
 	}
-	assert.EqualValuesf(t, "lpc", msdsn.ProtocolParsers[0].Protocol(), "lpc should be first protocol")
+	assert.EqualValuesf(t, "lpc", msdsn.ProtocolParsers[2].Protocol(), "lpc should be third protocol")
 	assert.Truef(t, msdsn.ProtocolParsers[1].Hidden(), "Protocol %s should be hidden", msdsn.ProtocolParsers[1].Protocol())
-	assert.EqualValuesf(t, "tcp", msdsn.ProtocolParsers[2].Protocol(), "tcp should be second protocol")
-	assert.EqualValuesf(t, "np", msdsn.ProtocolParsers[3].Protocol(), "np should be third protocol")
+	assert.EqualValuesf(t, "tcp", msdsn.ProtocolParsers[0].Protocol(), "tcp should be first protocol")
+	assert.EqualValuesf(t, "np", msdsn.ProtocolParsers[3].Protocol(), "np should be fourth protocol")
 
 }

--- a/pkg/sqlcmd/sqlcmd_windows_amd64.go
+++ b/pkg/sqlcmd/sqlcmd_windows_amd64.go
@@ -6,14 +6,18 @@ import (
 	_ "github.com/microsoft/go-mssqldb/sharedmemory"
 )
 
+// Note: The order of includes above matters for namedpipe and sharedmemory.
+// Go tools always sort by name.
+// init() swaps shared memory protocol with np so it gets priority when dialing.
+
 func init() {
 	if len(msdsn.ProtocolParsers) == 4 {
-		// reorder the protocol parsers to lpc->admin->tcp->np
-		// ODBC follows this same order.
+		// reorder the protocol parsers to tcp->admin->lpc->np
 		// Named pipes/shared memory package doesn't support ARM
-		var tcp = msdsn.ProtocolParsers[0]
-		msdsn.ProtocolParsers[0] = msdsn.ProtocolParsers[3]
+		// Once there's a fix for https://github.com/natefinch/npipe/issues/34 incorporated into go-mssqldb,
+		// reorder to lpc->admin->np->tcp
+		var lpc = msdsn.ProtocolParsers[3]
 		msdsn.ProtocolParsers[3] = msdsn.ProtocolParsers[2]
-		msdsn.ProtocolParsers[2] = tcp
+		msdsn.ProtocolParsers[2] = lpc
 	}
 }


### PR DESCRIPTION
Fixes #373 
I don't know how I missed this behaviour when I added npipe to go-mssqldb.
