### PR TITLE
Update localization settings

### DIFF
--- a/internal/translations/LocProject.json
+++ b/internal/translations/LocProject.json
@@ -6,10 +6,10 @@
                 {
                     "SourceFile": "internal\\translations\\locales\\en-US\\out.gotext.json",
                     "CopyOption": "LangIDOnPath",
-                    "Languages": "de-de;fr-fr;it-it;es-es;ja-jp;ko-kr,zh-cn,zh-tw,pt-br,ru-ru",
+                    "Languages": "de-DE;fr-FR;it-IT;es-ES;ja-JP;ko-KR,zh-CN,zh-TW,pt-BR,ru-RU",
                     "LssFiles": ["internal\\translations\\P306PairNamesToProcess.lss"],
                     "LclFile": "internal\\translations\\LCL\\{Lang}\\out.gotext.json.lcl",
-                    "OutputPath": "internal\\translations\\locales"
+                    "OutputPath": "internal\\translations\\localized"
                 }
             ]
         }


### PR DESCRIPTION
This commit update the language IDs so that the localization artifacts are generated 
in same directories as the ones generated by Golang localization framework.
The output path is intentionally kept different to make sure that the initial pipeline
run does not affect the existing builds which contains partial localized data.
The localization team will checkin the localized artifacts in the output path.
We will keep the content received from localization team and the one used by our builds 
in sync via script. 