### PR TITLE
Fix mac builds

### DIFF
--- a/cmd/modern/root/open/ads_darwin.go
+++ b/cmd/modern/root/open/ads_darwin.go
@@ -6,6 +6,7 @@ package open
 import (
 	"github.com/microsoft/go-sqlcmd/cmd/modern/sqlconfig"
 	"github.com/microsoft/go-sqlcmd/internal/cmdparser"
+	"github.com/microsoft/go-sqlcmd/internal/localizer"
 )
 
 // Type Ads is used to implement the "open ads" which launches Azure


### PR DESCRIPTION
Mac builds failed with following error
```
# github.com/microsoft/go-sqlcmd/cmd/modern/root/open
root/open/ads_darwin.go:31:14: undefined: localizer
##[error]The Go task failed with an error: Error: The process '/Users/runner/hostedtoolcache/go/1.18.0/x64/bin/go' failed with exit code 2
```
VS Code did not throw errors/warning as it warned that this file is within mdule "." which is not included in workspace.