### PR TITLE
Add product name and description to output

### DIFF
--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -224,6 +224,7 @@ func Execute(version string) {
 			setVars(vars, &args)
 
 			if args.Version {
+				fmt.Println(localizer.Sprintf("sqlcmd: Install/Create/Query SQL Server, Azure SQL, and Tools"))
 				fmt.Printf("%v\n", version)
 				fmt.Println(localizer.Sprintf("Legal docs and information: aka.ms/SqlcmdLegal"))
 				fmt.Println(localizer.Sprintf("Third party notices: aka.ms/SqlcmdNotices"))
@@ -243,6 +244,7 @@ func Execute(version string) {
 	setFlags(rootCmd, &args)
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, argss []string) {
 		fmt.Println(cmd.Long)
+		fmt.Println(localizer.Sprintf("sqlcmd: Install/Create/Query SQL Server, Azure SQL, and Tools"))
 		fmt.Println(localizer.Sprintf("Version %v\n", version))
 		cmd.Flags().SetInterspersed(false)
 		fmt.Println(localizer.Sprintf("Flags:"))


### PR DESCRIPTION
Add product name to `--version` and `-?` output, to emulate the output of sqlcmd ODBC.