### PR TITLE
Add -N strict option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ The `sqlcmd` project aims to be a complete port of the original ODBC sqlcmd to t
 The following switches have different behavior in this version of `sqlcmd` compared to the original ODBC based `sqlcmd`.
 - `-R` switch is ignored. The go runtime does not provide access to user locale information, and it's not readily available through syscall on all supported platforms.
 - `-I` switch is ignored; quoted identifiers are always set on. To disable quoted identifier behavior, add `SET QUOTED IDENTIFIER OFF` in your scripts.
-- `-N` now takes a string value that can be one of `true`, `false`, or `disable` to specify the encryption choice. 
+- `-N` now takes a string value that can be one of `strict`,`true`,`mandatory`,`yes`,`1`,`t`, `optional`, `no`, `0`, `f`, `false`, or `disable` to specify the encryption choice. 
   - If `-N` and `-C` are not provided, sqlcmd will negotiate authentication with the server without validating the server certificate.
   - If `-N` is provided but `-C` is not, sqlcmd will require validation of the server certificate. Note that a `false` value for encryption could still lead to encryption of the login packet.
+  - `-C` has no effect when `strict` value is specified for `-N`.
   - If both `-N` and `-C` are provided, sqlcmd will use their values for encryption negotiation.
   - More information about client/server encryption negotiation can be found at <https://docs.microsoft.com/openspecs/windows_protocols/ms-tds/60f56408-0188-4cd5-8b90-25c6f2423868>
 - `-u` The generated Unicode output file will have the UTF16 Little-Endian Byte-order mark (BOM) written to it.

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -450,10 +450,10 @@ func normalizeFlags(cmd *cobra.Command) error {
 		case encryptConnection:
 			value := strings.ToLower(v)
 			switch value {
-			case "false", "true", "disable":
+			case "mandatory", "yes", "1", "t", "true", "disable", "optional", "no", "0", "f", "false", "strict":
 				return pflag.NormalizedName(name)
 			default:
-				err = invalidParameterError("-N", v, "false", "true", "disable")
+				err = invalidParameterError("-N", v, "mandatory", "yes", "1", "t", "true", "disable", "optional", "no", "0", "f", "false", "strict")
 				return pflag.NormalizedName("")
 			}
 		case format:

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -150,6 +150,7 @@ func TestInvalidCommandLine(t *testing.T) {
 		{[]string{"-P"}, "'-P': Missing argument. Enter '-?' for help."},
 		{[]string{"-;"}, "';': Unknown Option. Enter '-?' for help."},
 		{[]string{"-t", "-2"}, "'-t -2': value must be greater than or equal to 0 and less than or equal to 65534."},
+		{[]string{"-N", "invalid"}, "'-N invalid': Unexpected argument. Argument value has to be one of [mandatory yes 1 t true disable optional no 0 f false strict]."},
 	}
 
 	for _, test := range commands {


### PR DESCRIPTION
Fixes #430 

Validation:
With unknown CA
```
git\go-sqlcmd>.\sqlcmd.exe -Slocalhost:1434 -Usa -P<masked> -N "strict"
TLS Handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority
TLS Handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority

git\go-sqlcmd>.\sqlcmd.exe -Slocalhost:1434 -Usa -P<masked> -N "strict" -C
TLS Handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority
TLS Handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority
```

With known CA
```
git\go-sqlcmd>.\sqlcmd.exe -S<redacted>.database.windows.net:1433 -U<masked> -P<masked> -N "strict"
1> select @@version
2> go


------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Microsoft SQL Azure (RTM) - 12.0.2000.8
        Jul 17 2023 18:40:52
        Copyright (C) 2022 Microsoft Corporation


(1 row affected)
1> SELECT protocol_type, CONVERT(varbinary(9),protocol_version),client_net_address from sys.dm_exec_connections where session_id=@@SPID
2> go
protocol_type                                      client_net_address
---------------------------------------- --------- ------------------------------------------------
TSQL                                     0x0800000 58.84.60.222

(1 row affected)
1> exit

```