### PR TITLE
Backward compat support for -N

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -587,8 +587,8 @@ Apache License
 ## github.com/docker/docker
 
 * Name: github.com/docker/docker
-* Version: v24.0.6
-* License: [Apache-2.0](https://github.com/docker/docker/blob/v24.0.6/LICENSE)
+* Version: v24.0.7
+* License: [Apache-2.0](https://github.com/docker/docker/blob/v24.0.7/LICENSE)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ The `sqlcmd` project aims to be a complete port of the original ODBC sqlcmd to t
 The following switches have different behavior in this version of `sqlcmd` compared to the original ODBC based `sqlcmd`.
 - `-R` switch is ignored. The go runtime does not provide access to user locale information, and it's not readily available through syscall on all supported platforms.
 - `-I` switch is ignored; quoted identifiers are always set on. To disable quoted identifier behavior, add `SET QUOTED IDENTIFIER OFF` in your scripts.
-- `-N` now takes a string value that can be one of `strict`,`true`,`mandatory`,`yes`,`1`,`t`, `optional`, `no`, `0`, `f`, `false`, or `disable` to specify the encryption choice. 
+- `-N` now takes an optional string value that can be one of `strict`,`true`,`mandatory`,`yes`,`1`,`t`, `optional`, `no`, `0`, `f`, `false`, or `disable` to specify the encryption choice.
+  - If `-N` is passed but no value is provided, `true` is used.
   - If `-N` and `-C` are not provided, sqlcmd will negotiate authentication with the server without validating the server certificate.
   - If `-N` is provided but `-C` is not, sqlcmd will require validation of the server certificate. Note that a `false` value for encryption could still lead to encryption of the login packet.
   - `-C` has no effect when `strict` value is specified for `-N`.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The `sqlcmd` project aims to be a complete port of the original ODBC sqlcmd to t
 The following switches have different behavior in this version of `sqlcmd` compared to the original ODBC based `sqlcmd`.
 - `-R` switch is ignored. The go runtime does not provide access to user locale information, and it's not readily available through syscall on all supported platforms.
 - `-I` switch is ignored; quoted identifiers are always set on. To disable quoted identifier behavior, add `SET QUOTED IDENTIFIER OFF` in your scripts.
-- `-N` now takes an optional string value that can be one of `strict`,`true`,`mandatory`,`yes`,`1`,`t`, `optional`, `no`, `0`, `f`, `false`, or `disable` to specify the encryption choice.
+- `-N` now takes an optional string value that can be one of `s[trict]`,`t[rue]`,`m[andatory]`, `yes`,`1`, `o[ptional]`,`no`, `0`, `f[alse]`, or `disable` to specify the encryption choice.
   - If `-N` is passed but no value is provided, `true` is used.
   - If `-N` and `-C` are not provided, sqlcmd will negotiate authentication with the server without validating the server certificate.
   - If `-N` is provided but `-C` is not, sqlcmd will require validation of the server certificate. Note that a `false` value for encryption could still lead to encryption of the login packet.

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -460,10 +460,10 @@ func normalizeFlags(cmd *cobra.Command) error {
 		case encryptConnection:
 			value := strings.ToLower(v)
 			switch value {
-			case "mandatory", "yes", "1", "t", "true", "disable", "optional", "no", "0", "f", "false", "strict":
+			case "mandatory", "yes", "1", "t", "true", "disable", "optional", "no", "0", "f", "false", "strict", "m", "s", "o":
 				return pflag.NormalizedName(name)
 			default:
-				err = invalidParameterError("-N", v, "mandatory", "yes", "1", "t", "true", "disable", "optional", "no", "0", "f", "false", "strict")
+				err = invalidParameterError("-N", v, "m[andatory]", "yes", "1", "t", "true", "disable", "o[ptional]", "no", "0", "f", "false", "s[trict]")
 				return pflag.NormalizedName("")
 			}
 		case format:
@@ -685,7 +685,16 @@ func setConnect(connect *sqlcmd.ConnectSettings, args *SQLCmdArguments, vars *sq
 	connect.DisableVariableSubstitution = args.DisableVariableSubstitution
 	connect.ApplicationIntent = args.ApplicationIntent
 	connect.LoginTimeoutSeconds = args.LoginTimeout
-	connect.Encrypt = args.EncryptConnection
+	switch args.EncryptConnection {
+	case "s":
+		connect.Encrypt = "strict"
+	case "o":
+		connect.Encrypt = "optional"
+	case "m":
+		connect.Encrypt = "mandatory"
+	default:
+		connect.Encrypt = args.EncryptConnection
+	}
 	connect.PacketSize = args.PacketSize
 	connect.WorkstationName = args.WorkstationName
 	connect.LogLevel = args.DriverLoggingLevel

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -467,7 +467,7 @@ func normalizeFlags(cmd *cobra.Command) error {
 			case "mandatory", "yes", "1", "t", "true", "disable", "optional", "no", "0", "f", "false", "strict", "m", "s", "o":
 				return pflag.NormalizedName(name)
 			default:
-				err = invalidParameterError("-N", v, "m[andatory]", "yes", "1", "t", "true", "disable", "o[ptional]", "no", "0", "f", "false", "s[trict]")
+				err = invalidParameterError("-N", v, "m[andatory]", "yes", "1", "t[rue]", "disable", "o[ptional]", "no", "0", "f[alse]", "s[trict]")
 				return pflag.NormalizedName("")
 			}
 		case format:

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -310,6 +310,7 @@ func checkDefaultValue(args []string, i int) (val string) {
 		'k': "0",
 		'L': "|", // | is the sentinel for no value since users are unlikely to use it. It's "reserved" in most shells
 		'X': "0",
+		'N': "true",
 	}
 	if isFlag(args[i]) && (len(args) == i+1 || args[i+1][0] == '-') {
 		if v, ok := flags[rune(args[i][1])]; ok {

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -102,6 +102,9 @@ func TestValidCommandLineToArgsConversion(t *testing.T) {
 		{[]string{"-N"}, func(args SQLCmdArguments) bool {
 			return args.EncryptConnection == "true"
 		}},
+		{[]string{"-N", "m"}, func(args SQLCmdArguments) bool {
+			return args.EncryptConnection == "m"
+		}},
 	}
 
 	for _, test := range commands {
@@ -529,6 +532,42 @@ func TestConvertOsArgs(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			actual := convertOsArgs(c.in)
 			assert.ElementsMatch(t, c.expected, actual, "Incorrect converted args")
+		})
+	}
+}
+
+func TestEncryptionOptions(t *testing.T) {
+	type test struct {
+		input  string
+		output string
+	}
+	tests := []test{
+		{
+			"s",
+			"strict",
+		},
+		{
+			"m",
+			"mandatory",
+		},
+		{
+			"o",
+			"optional",
+		},
+		{
+			"mandatory",
+			"mandatory",
+		},
+	}
+	for _, c := range tests {
+		t.Run(c.input, func(t *testing.T) {
+			args := newArguments()
+			args.EncryptConnection = c.input
+			vars := sqlcmd.InitializeVariables(false)
+			setVars(vars, &args)
+			var connectConfig sqlcmd.ConnectSettings
+			setConnect(&connectConfig, &args, vars)
+			assert.Equal(t, c.output, connectConfig.Encrypt, "Incorrect connect.Encrypt")
 		})
 	}
 }

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -99,6 +99,9 @@ func TestValidCommandLineToArgsConversion(t *testing.T) {
 		{[]string{"-k", "-X", "-r", "-z", "something"}, func(args SQLCmdArguments) bool {
 			return args.warnOnBlockedCmd() && !args.useEnvVars() && args.getControlCharacterBehavior() == sqlcmd.ControlRemove && *args.ErrorsToStderr == 0 && args.ChangePassword == "something"
 		}},
+		{[]string{"-N"}, func(args SQLCmdArguments) bool {
+			return args.EncryptConnection == "true"
+		}},
 	}
 
 	for _, test := range commands {

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -156,7 +156,7 @@ func TestInvalidCommandLine(t *testing.T) {
 		{[]string{"-P"}, "'-P': Missing argument. Enter '-?' for help."},
 		{[]string{"-;"}, "';': Unknown Option. Enter '-?' for help."},
 		{[]string{"-t", "-2"}, "'-t -2': value must be greater than or equal to 0 and less than or equal to 65534."},
-		{[]string{"-N", "invalid"}, "'-N invalid': Unexpected argument. Argument value has to be one of [mandatory yes 1 t true disable optional no 0 f false strict]."},
+		{[]string{"-N", "invalid"}, "'-N invalid': Unexpected argument. Argument value has to be one of [m[andatory] yes 1 t[rue] disable o[ptional] no 0 f[alse] s[trict]]."},
 	}
 
 	for _, test := range commands {


### PR DESCRIPTION
treat `-N` by itself as `-N true`
Fixes #497 