### PR TITLE
update Go  tools to 1.21

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.18'
+        go-version: '1.21'
     - name: Run tests against Linux SQL
       run: |
         go version

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -4712,8 +4712,8 @@ THE SOFTWARE.
 ## golang.org/x/crypto
 
 * Name: golang.org/x/crypto
-* Version: v0.14.0
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/crypto/+/v0.14.0:LICENSE)
+* Version: v0.17.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/crypto/+/v0.17.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4786,8 +4786,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/sys/windows
 
 * Name: golang.org/x/sys/windows
-* Version: v0.13.0
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.13.0:LICENSE)
+* Version: v0.15.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.15.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4823,8 +4823,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## golang.org/x/text
 
 * Name: golang.org/x/text
-* Version: v0.13.0
-* License: [BSD-3-Clause](https://cs.opensource.google/go/x/text/+/v0.13.0:LICENSE)
+* Version: v0.14.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/text/+/v0.14.0:LICENSE)
 
 ```
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/build/azure-pipelines/build-common.yml
+++ b/build/azure-pipelines/build-common.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
 - task: GoTool@0
   inputs:
-    version: '1.18'
+    version: '1.21'
     goBin: $(Build.SourcesDirectory)
 
 - task: Go@0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/go-sqlcmd
 
-go 1.18
+go 1.21
 
 require (
 	github.com/alecthomas/chroma/v2 v2.5.0


### PR DESCRIPTION
Fixes #499 (though I don't think that CVE is relevant since we don't use `cgo`)
We should use a new toolset anyway.