### PR TITLE
fix: Parse list flags correctly

### DIFF
--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -294,8 +294,8 @@ func convertOsArgs(args []string) (cargs []string) {
 		}
 		var defValue string
 		if isListFlag(a) {
-			flag = a
-			first = true
+			flag = a[0:2]
+			first = len(a) == 2
 		} else {
 			defValue = checkDefaultValue(args, i)
 		}
@@ -326,11 +326,11 @@ func checkDefaultValue(args []string, i int) (val string) {
 }
 
 func isFlag(arg string) bool {
-	return len(arg) == 2 && arg[0] == '-'
+	return arg[0] == '-'
 }
 
 func isListFlag(arg string) bool {
-	return arg == "-v" || arg == "-i"
+	return len(arg) > 1 && (arg[0:2] == "-v" || arg[0:2] == "-i")
 }
 
 func formatDescription(description string, maxWidth, indentWidth int) string {

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -105,6 +105,9 @@ func TestValidCommandLineToArgsConversion(t *testing.T) {
 		{[]string{"-N", "m"}, func(args SQLCmdArguments) bool {
 			return args.EncryptConnection == "m"
 		}},
+		{[]string{"-ifoo.sql", "bar.sql", "-V10"}, func(args SQLCmdArguments) bool {
+			return args.ErrorSeverityLevel == 10 && args.InputFile[0] == "foo.sql" && args.InputFile[1] == "bar.sql"
+		}},
 	}
 
 	for _, test := range commands {
@@ -526,6 +529,16 @@ func TestConvertOsArgs(t *testing.T) {
 			"Flags with optional arguments",
 			[]string{"-r", "1", "-X", "-k", "-C"},
 			[]string{"-r", "1", "-X", "0", "-k", "0", "-C"},
+		},
+		{
+			"-i followed by flags without spaces",
+			[]string{"-i", "a.sql", "-V10", "-C"},
+			[]string{"-i", "a.sql", "-V10", "-C"},
+		},
+		{
+			"list flags without spaces",
+			[]string{"-ifoo.sql", "bar.sql", "-V10", "-X", "-va=b", "c=d"},
+			[]string{"-ifoo.sql", "-i", "bar.sql", "-V10", "-X", "0", "-va=b", "-v", "c=d"},
 		},
 	}
 	for _, c := range tests {


### PR DESCRIPTION
Handle multiple `-i` and `-v` entries correctly when they are followed by a flag-without-space like `-isomefile1 somefile2 -V10`