### PR TITLE
fix: When both -Q and -q are specified, take -Q input and finish

### DIFF
--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -811,11 +811,11 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 
 	if err == nil && s.Exitcode == 0 {
 		once := false
-		if args.InitialQuery != "" {
-			s.Query = args.InitialQuery
-		} else if args.Query != "" {
+		if args.Query != "" {
 			once = true
 			s.Query = args.Query
+		} else if args.InitialQuery != "" {
+			s.Query = args.InitialQuery
 		}
 		iactive := args.InputFile == nil && args.Query == ""
 		if iactive || s.Query != "" {


### PR DESCRIPTION
Would this be a good fix for the issue #525 when both -Q and -q are specified.

By switching priority, when both are specified, it takes -Q first, and finishes. The app no more crashes.

If we would like to report error instead, maybe I could do it in another PR.

Example output
```
> ./sqlcmd -S "tcp:127.0.0.1,1433" -E -d master -q "SELECT 1" -Q "SELECT 2"

-----------
          2

(1 row affected)
```