### PR TITLE
bump to docker v27.3.1+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.5.0
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/docker/docker v25.0.6+incompatible
+	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/golang-sql/sqlexp v0.1.0
 	github.com/google/uuid v1.6.0
@@ -57,6 +57,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/term v0.0.0-20221120202655-abb19827d345 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m3
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v25.0.6+incompatible h1:5cPwbwriIcsua2REJe8HqQV+6WlWc1byg2QSXzBxBGg=
 github.com/docker/docker v25.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.3.1+incompatible h1:KttF0XoteNTicmUtBO0L2tP+J7FGRFTjaEF4k6WdhfI=
+github.com/docker/docker v27.3.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
@@ -253,6 +255,8 @@ github.com/microsoft/go-mssqldb v1.7.2 h1:CHkFJiObW7ItKTJfHo1QX7QBBD1iV+mn1eOyRP
 github.com/microsoft/go-mssqldb v1.7.2/go.mod h1:kOvZKUdrhhFQmxLZqbwUV0rHkNkZpthMITIb2Ko1IoA=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.0.0-20221120202655-abb19827d345 h1:J9c53/kxIH+2nTKBEfZYFMlhghtHpIHSXpm5VRGHSnU=
 github.com/moby/term v0.0.0-20221120202655-abb19827d345/go.mod h1:15ce4BGCFxt7I5NQKT+HV0yEDxmf6fSysfEDiVo3zFM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/container/controller.go
+++ b/internal/container/controller.go
@@ -34,7 +34,10 @@ type Controller struct {
 func NewController() (c *Controller) {
 	var err error
 	c = new(Controller)
-	c.cli, err = client.NewClientWithOpts(client.FromEnv)
+	c.cli, err = client.NewClientWithOpts(
+		client.FromEnv,
+		client.WithVersion("1.45"),
+	)
 	checkErr(err)
 
 	return

--- a/internal/container/controller.go
+++ b/internal/container/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
@@ -45,11 +46,11 @@ func NewController() (c *Controller) {
 // if one occurred while creating the client. The Controller struct has a
 // method EnsureImage() which pulls an image with the given name from
 // a registry and logs the output to the console.
-func (c Controller) EnsureImage(image string) (err error) {
+func (c Controller) EnsureImage(imageName string) (err error) {
 	var reader io.ReadCloser
 
-	trace("Running ImagePull for image %s", image)
-	reader, err = c.cli.ImagePull(context.Background(), image, types.ImagePullOptions{})
+	trace("Running ImagePull for image %s", imageName)
+	reader, err = c.cli.ImagePull(context.Background(), imageName, image.PullOptions{})
 	if reader != nil {
 		defer func() {
 			checkErr(reader.Close())
@@ -106,7 +107,7 @@ func (c Controller) ContainerRun(
 	err = c.cli.ContainerStart(
 		context.Background(),
 		resp.ID,
-		types.ContainerStartOptions{},
+		container.StartOptions{},
 	)
 	if err != nil || unitTestFailure {
 		// Remove the container, because we haven't persisted to config yet, so
@@ -131,7 +132,7 @@ func (c Controller) ContainerRun(
 // This function is useful for waiting until a specific event has occurred in the
 // container (e.g. a server has started up) before continuing with other operations.
 func (c Controller) ContainerWaitForLogEntry(id string, text string) {
-	options := types.ContainerLogsOptions{
+	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: false,
 		Since:      "",
@@ -177,7 +178,7 @@ func (c Controller) ContainerStart(id string) (err error) {
 		panic("Must pass in non-empty id")
 	}
 
-	err = c.cli.ContainerStart(context.Background(), id, types.ContainerStartOptions{})
+	err = c.cli.ContainerStart(context.Background(), id, container.StartOptions{})
 	return
 }
 
@@ -329,7 +330,7 @@ func (c Controller) ContainerExists(id string) (exists bool) {
 	)
 	resp, err := c.cli.ContainerList(
 		context.Background(),
-		types.ContainerListOptions{Filters: f},
+		container.ListOptions{Filters: f},
 	)
 	checkErr(err)
 	if len(resp) > 0 {
@@ -352,7 +353,7 @@ func (c Controller) ContainerRemove(id string) (err error) {
 		panic("Must pass in non-empty id")
 	}
 
-	options := types.ContainerRemoveOptions{
+	options := container.RemoveOptions{
 		RemoveVolumes: false,
 		RemoveLinks:   false,
 		Force:         false,


### PR DESCRIPTION
This is to update version of docker/docker to address [CVE-2024-36623](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-36623), docker/docker version 25.0.6 is vulnerable to Race Condition vulnerability.
