### PR TITLE
feat: add CI action for publishing package to WinGet

### DIFF
--- a/.github/workflows/submit-winget.yml
+++ b/.github/workflows/submit-winget.yml
@@ -1,0 +1,31 @@
+name: Submit published release to WinGet community repository
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+    runs-on: windows-latest
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      # Sometimes wingetcreate may fail to sync fork automatically, so we do it manually here.
+      # Ref: https://github.com/microsoft/winget-create/issues/502
+      - name: Sync winget-pkgs fork
+        # TODO: Replace <repo-owner> with the owner of the fork
+        run: gh repo sync <repo-owner>/winget-pkgs -b master
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+      - name: Submit package using wingetcreate
+        run: |
+          # Get installer info from release event
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $x64InstallerUrl = $assets | Where-Object -Property name -eq 'sqlcmd-amd64.msi' | Select-Object -ExpandProperty browser_download_url
+          $armInstallerUrl = $assets | Where-Object -Property name -eq 'sqlcmd-arm.msi' | Select-Object -ExpandProperty browser_download_url
+          $arm64InstallerUrl = $assets | Where-Object -Property name -eq 'sqlcmd-arm64.msi' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Microsoft.Sqlcmd --version $packageVersion --urls "$x64InstallerUrl|x64" "$armInstallerUrl|arm" "$arm64InstallerUrl|arm64" --submit --token "${{ secrets.WINGET_GITHUB_TOKEN }}"

--- a/.github/workflows/submit-winget.yml
+++ b/.github/workflows/submit-winget.yml
@@ -7,25 +7,28 @@ on:
 jobs:
   publish-winget:
     name: Submit to WinGet repository
+    # winget-create is only supported on Windows
     runs-on: windows-latest
+    permissions:
+      contents: read
+    env:
+      # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+      # See https://aka.ms/winget-create-token
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+    # Only submit stable releases
     if: ${{ !github.event.release.prerelease }}
     steps:
-      # Sometimes wingetcreate may fail to sync fork automatically, so we do it manually here.
-      # Ref: https://github.com/microsoft/winget-create/issues/502
-      - name: Sync winget-pkgs fork
-        # TODO: Replace <repo-owner> with the owner of the fork
-        run: gh repo sync <repo-owner>/winget-pkgs -b master
-        env:
-          GH_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
       - name: Submit package using wingetcreate
         run: |
           # Get installer info from release event
           $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
           $x64InstallerUrl = $assets | Where-Object -Property name -eq 'sqlcmd-amd64.msi' | Select-Object -ExpandProperty browser_download_url
-          $armInstallerUrl = $assets | Where-Object -Property name -eq 'sqlcmd-arm.msi' | Select-Object -ExpandProperty browser_download_url
           $arm64InstallerUrl = $assets | Where-Object -Property name -eq 'sqlcmd-arm64.msi' | Select-Object -ExpandProperty browser_download_url
           $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
 
           # Update package using wingetcreate
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update Microsoft.Sqlcmd --version $packageVersion --urls "$x64InstallerUrl|x64" "$armInstallerUrl|arm" "$arm64InstallerUrl|arm64" --submit --token "${{ secrets.WINGET_GITHUB_TOKEN }}"
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update Microsoft.Sqlcmd `
+            --version $packageVersion `
+            --urls $x64InstallerUrl $arm64InstallerUrl `
+            --submit


### PR DESCRIPTION
- Related to #131

This PR proposes to add a GitHub action for submitting the latest stable release to WinGet as it gets published. [microsoft/winget-create](https://github.com/microsoft/winget-create) is used as the tool for submitting the latest package.

## Steps needed from maintainers

If the maintainers approve of these changes, they will need to do the following before merging this PR:

- Add a repository secret named `WINGET_CREATE_GITHUB_TOKEN` that's a [public access token (classic)](https://github.com/microsoft/winget-create/blob/main/doc/token.md#github-personal-access-token-classic-permissions) with [`public_repo`](https://raw.githubusercontent.com/microsoft/winget-create/main/doc/images/tokenscope-publicrepo.png) scope from the user account where the winget-pkgs fork will exist for submitting a PR. Recommend using a bot account for this purpose.


For reference, maintainers may see similar implemented actions in the following repos:
- [Microsoft PowerToys](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml)
- [Microsoft Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml)
- [Microsoft Copilot CLI](https://github.com/github/copilot-cli/blob/v0.0.368-2/.github/workflows/winget.yml)
- [Microsoft Edit](https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml)
- [WinGet Studio](https://github.com/microsoft/winget-studio/blob/main/.github/workflows/winget.yml)
- [Oh-My-Posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/release.yml)