### PR TITLE
feat: add --no-bom flag for ODBC sqlcmd compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The following switches have different behavior in this version of `sqlcmd` compa
   - If both `-N` and `-C` are provided, sqlcmd will use their values for encryption negotiation.
   - To provide the value of the host name in the server certificate when using strict encryption, pass the host name with `-F`. Example: `-Ns -F myhost.domain.com`
   - More information about client/server encryption negotiation can be found at <https://docs.microsoft.com/openspecs/windows_protocols/ms-tds/60f56408-0188-4cd5-8b90-25c6f2423868>
-- `-u` The generated Unicode output file will have the UTF16 Little-Endian Byte-order mark (BOM) written to it.
+- `-u` The generated Unicode output file will have the UTF16 Little-Endian Byte-order mark (BOM) written to it. ODBC sqlcmd does not write a BOM; use `--no-bom` with `-u` if you need strict ODBC compatibility.
 - Some behaviors that were kept to maintain compatibility with `OSQL` may be changed, such as alignment of column headers for some data types.
 - All commands must fit on one line, even `EXIT`. Interactive mode will not check for open parentheses or quotes for commands and prompt for successive lines. The ODBC sqlcmd allows the query run by `EXIT(query)` to span multiple lines.
 - `-i` doesn't handle a comma `,` in a file name correctly unless the file name argument is triple quoted. For example:

--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -321,9 +321,12 @@ func outCommand(s *Sqlcmd, args []string, line uint) error {
 			return InvalidFileError(err, args[0])
 		}
 		if s.UnicodeOutputFile {
-			// ODBC sqlcmd doesn't write a BOM but we will.
-			// Maybe the endian-ness should be configurable.
-			win16le := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)
+			// By default we write a BOM, but --no-bom omits it for ODBC sqlcmd compatibility
+			bomPolicy := unicode.UseBOM
+			if s.NoBOM {
+				bomPolicy = unicode.IgnoreBOM
+			}
+			win16le := unicode.UTF16(unicode.LittleEndian, bomPolicy)
 			encoder := transform.NewWriter(o, win16le.NewEncoder())
 			s.SetOutput(encoder)
 		} else {

--- a/pkg/sqlcmd/sqlcmd.go
+++ b/pkg/sqlcmd/sqlcmd.go
@@ -84,6 +84,8 @@ type Sqlcmd struct {
 	PrintError func(msg string, severity uint8) bool
 	// UnicodeOutputFile is true when UTF16 file output is needed
 	UnicodeOutputFile bool
+	// NoBOM omits the BOM from UTF-16 output files (ODBC sqlcmd compatibility)
+	NoBOM bool
 	// EchoInput tells the GO command to print the batch text before running the query
 	EchoInput bool
 	colorizer color.Colorizer


### PR DESCRIPTION
By default, -u (unicode output) includes a UTF-16 LE BOM (FF FE) at the start of output files. ODBC sqlcmd does not write a BOM. This adds --no-bom flag to omit the BOM when strict ODBC compatibility is needed. Usage: sqlcmd -u --no-bom -o output.txt. Also updates README to document the difference.