### PR TITLE
docs: update README for documentation freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Most switches from the original ODBC-based `sqlcmd` have been implemented. The f
 
 | Switch | Description |
 |--------|-------------|
+| `-f` | Input/output code page |
 | `-j` | Print raw error messages |
 | `-p[1]` | Print statistics (optional colon format) |
 
@@ -222,7 +223,7 @@ To use AAD auth, you can use one of two command line switches:
 
 `ActiveDirectoryIntegrated`
 
-This method uses integrated Windows authentication. On Windows, it uses the current user's credentials. On Linux and macOS, it uses Kerberos authentication (requires a properly configured Kerberos environment).
+This method is not fully implemented in the go-mssqldb driver and currently falls back to `ActiveDirectoryDefault`.
 
 `ActiveDirectoryPassword`
 
@@ -254,13 +255,13 @@ This method uses the device code flow for authentication. It displays a code tha
 
 The following authentication methods are also supported via `--authentication-method`:
 
-- `ActiveDirectoryWorkloadIdentity` - For workload identity federation scenarios
-- `ActiveDirectoryClientAssertion` - For client assertion authentication
-- `ActiveDirectoryAzurePipelines` - For Azure Pipelines service connections
-- `ActiveDirectoryEnvironment` - Uses environment variables for authentication
-- `ActiveDirectoryAzureDeveloperCli` - Uses Azure Developer CLI credentials
-- `ActiveDirectoryServicePrincipalAccessToken` - Uses a pre-obtained access token
-- `SqlPassword` - SQL Server authentication (same as using `-U` and `-P` without `-G`)
+- `ActiveDirectoryWorkloadIdentity` - Uses federated token authentication for Kubernetes or GitHub Actions workloads; optionally provide `client_id@tenant_id` as username and `tokenfilepath` parameter (defaults to `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` env vars)
+- `ActiveDirectoryClientAssertion` - Authenticates with a signed JWT assertion instead of a client secret
+- `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection; requires `client_id@tenant_id` as username, plus `serviceconnectionid` and `systemtoken` connection parameters (or `AZURESUBSCRIPTION_CLIENT_ID`, `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID`, `SYSTEM_ACCESSTOKEN` env vars)
+- `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password)
+- `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI)
+- `ActiveDirectoryServicePrincipalAccessToken` - Uses a pre-obtained bearer token; set `SQLCMDPASSWORD` to the access token value
+- `SqlPassword` - SQL Server authentication (equivalent to `-U` and `-P` without `-G`)
 
 #### Environment variables for AAD auth
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For historical context and to provide feedback, see [discussion #292](https://gi
 ### Miscellaneous enhancements
 
 - Console output coloring (see below)
-- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlAuthentication`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`, `ActiveDirectoryInteractive`, `ActiveDirectoryAzCli`, `ActiveDirectoryDeviceCode`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` username parameter.
+- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlPassword`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`, `ActiveDirectoryInteractive`, `ActiveDirectoryAzCli`, `ActiveDirectoryDeviceCode`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` username parameter.
 - The new `--driver-logging-level` command line parameter allows you to see traces from the `go-mssqldb` client driver. Use `64` to see all traces.
 - Sqlcmd can now print results using a vertical format. Use the new `--vertical` command line option to set it. It's also controlled by the `SQLCMDFORMAT` scripting variable.
 
@@ -255,13 +255,13 @@ This method uses the device code flow for authentication. It displays a code tha
 
 The following authentication methods are also supported via `--authentication-method`:
 
-- `ActiveDirectoryWorkloadIdentity` - Uses federated token authentication for Kubernetes or GitHub Actions workloads; optionally provide `client_id@tenant_id` as username and set the `tokenfilepath` connection parameter to the path of the federated token file (defaults to `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` env vars)
-- `ActiveDirectoryClientAssertion` - Authenticates with a signed JWT assertion instead of a client secret; provide `client_id@tenant_id` as username and the signed JWT as the password (`-P` or `SQLCMDPASSWORD`)
-- `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection; requires `client_id@tenant_id` as username, plus `serviceconnectionid` and `systemtoken` connection parameters (or `AZURESUBSCRIPTION_CLIENT_ID`, `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID`, `SYSTEM_ACCESSTOKEN` env vars)
-- `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password)
-- `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI)
-- `ActiveDirectoryServicePrincipalAccessToken` - Uses a pre-obtained bearer token; set `SQLCMDPASSWORD` to the access token value
-- `SqlPassword` - SQL Server authentication (equivalent to `-U` and `-P` without `-G`)
+- `ActiveDirectoryWorkloadIdentity` - Uses federated token authentication for Kubernetes or GitHub Actions workloads. Optionally provide `client_id@tenant_id` as username. The token file path and tenant/client IDs are read from the `AZURE_FEDERATED_TOKEN_FILE`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_ID` environment variables; sqlcmd does not expose a way to pass these as connection parameters.
+- `ActiveDirectoryClientAssertion` - Authenticates with a signed JWT assertion instead of a client secret; provide `client_id@tenant_id` as username and the signed JWT as the password (`-P` or `SQLCMDPASSWORD`).
+- `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection. Requires `client_id@tenant_id` as username. The service connection ID and system access token are read from the `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` and `SYSTEM_ACCESSTOKEN` environment variables (with `AZURESUBSCRIPTION_CLIENT_ID` as a fallback for the client ID); sqlcmd does not expose a way to pass these as connection parameters.
+- `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password).
+- `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI).
+- `ActiveDirectoryServicePrincipalAccessToken` - Intended to use a pre-obtained bearer token, but sqlcmd does not currently propagate `SQLCMDPASSWORD` (or `-P`) into the connection string for this method, so the token is not passed to the driver. Do not rely on this method until that gap is closed.
+- `SqlPassword` - SQL Server authentication (equivalent to `-U` and `-P` without `-G`).
 
 #### Environment variables for AAD auth
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The following authentication methods are also supported via `--authentication-me
 - `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection. Requires `client_id@tenant_id` as username. The service connection ID and system access token are read from the `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` and `SYSTEM_ACCESSTOKEN` environment variables (with `AZURESUBSCRIPTION_CLIENT_ID` as a fallback for the client ID); sqlcmd does not expose a way to pass these as connection parameters.
 - `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password).
 - `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI).
-- `ActiveDirectoryServicePrincipalAccessToken` - Intended to use a pre-obtained bearer token. sqlcmd does not currently propagate `SQLCMDPASSWORD` (or `-P`) into the connection string for this method, so the token is not reaching the driver; fix proposed in [#756](https://github.com/microsoft/go-sqlcmd/pull/756).
+- `ActiveDirectoryServicePrincipalAccessToken` - Authenticates with a pre-obtained AAD bearer token. Pass the token as the password (`-P` or `SQLCMDPASSWORD`); the username is ignored.
 - `SqlPassword` - SQL Server authentication (equivalent to `-U` and `-P` without `-G`).
 
 #### Environment variables for AAD auth

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The following authentication methods are also supported via `--authentication-me
 - `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection. Requires `client_id@tenant_id` as username. The service connection ID and system access token are read from the `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` and `SYSTEM_ACCESSTOKEN` environment variables (with `AZURESUBSCRIPTION_CLIENT_ID` as a fallback for the client ID); sqlcmd does not expose a way to pass these as connection parameters.
 - `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password).
 - `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI).
-- `ActiveDirectoryServicePrincipalAccessToken` - Intended to use a pre-obtained bearer token. sqlcmd does not currently propagate `SQLCMDPASSWORD` (or `-P`) into the connection string for this method, so the token is not reaching the driver; tracked in [#758](https://github.com/microsoft/go-sqlcmd/issues/758).
+- `ActiveDirectoryServicePrincipalAccessToken` - Intended to use a pre-obtained bearer token. sqlcmd does not currently propagate `SQLCMDPASSWORD` (or `-P`) into the connection string for this method, so the token is not reaching the driver; fix proposed in [#756](https://github.com/microsoft/go-sqlcmd/pull/756).
 - `SqlPassword` - SQL Server authentication (equivalent to `-U` and `-P` without `-G`).
 
 #### Environment variables for AAD auth

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Most switches from the original ODBC-based `sqlcmd` have been implemented. The f
 | Switch | Description | Tracking |
 |--------|-------------|----------|
 | `-f` | Input/output code page | proposed in [#628](https://github.com/microsoft/go-sqlcmd/pull/628) (also see [#111](https://github.com/microsoft/go-sqlcmd/issues/111)) |
-| `-j` | Print raw error messages | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) (earlier attempt: [#624](https://github.com/microsoft/go-sqlcmd/pull/624), closed) |
+| `-j` | Print raw error messages | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) |
 | `-p[1]` | Print performance statistics after each result set. `-p1` uses colon-separated format for machine parsing | proposed in [#631](https://github.com/microsoft/go-sqlcmd/pull/631) |
 
 For historical context and to provide feedback, see [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292).

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Most switches from the original ODBC-based `sqlcmd` have been implemented. The f
 |--------|-------------|
 | `-f` | Input/output code page |
 | `-j` | Print raw error messages |
-| `-p[1]` | Print statistics (optional colon format) |
+| `-p[1]` | Print performance statistics after each result set. `-p1` uses colon-separated format for machine parsing |
 
 For historical context and to provide feedback, see [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292).
 
@@ -255,8 +255,8 @@ This method uses the device code flow for authentication. It displays a code tha
 
 The following authentication methods are also supported via `--authentication-method`:
 
-- `ActiveDirectoryWorkloadIdentity` - Uses federated token authentication for Kubernetes or GitHub Actions workloads; optionally provide `client_id@tenant_id` as username and `tokenfilepath` parameter (defaults to `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` env vars)
-- `ActiveDirectoryClientAssertion` - Authenticates with a signed JWT assertion instead of a client secret
+- `ActiveDirectoryWorkloadIdentity` - Uses federated token authentication for Kubernetes or GitHub Actions workloads; optionally provide `client_id@tenant_id` as username and set the `tokenfilepath` connection parameter to the path of the federated token file (defaults to `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` env vars)
+- `ActiveDirectoryClientAssertion` - Authenticates with a signed JWT assertion instead of a client secret; provide `client_id@tenant_id` as username and the signed JWT as the password (`-P` or `SQLCMDPASSWORD`)
 - `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection; requires `client_id@tenant_id` as username, plus `serviceconnectionid` and `systemtoken` connection parameters (or `AZURESUBSCRIPTION_CLIENT_ID`, `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID`, `SYSTEM_ACCESSTOKEN` env vars)
 - `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password)
 - `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI)

--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ The following switches have different behavior in this version of `sqlcmd` compa
 
 Most switches from the original ODBC-based `sqlcmd` have been implemented. The following switches are not yet available:
 
-| Switch | Description |
-|--------|-------------|
-| `-f` | Input/output code page |
-| `-j` | Print raw error messages |
-| `-p[1]` | Print performance statistics after each result set. `-p1` uses colon-separated format for machine parsing |
+| Switch | Description | Tracking |
+|--------|-------------|----------|
+| `-f` | Input/output code page | proposed in [#628](https://github.com/microsoft/go-sqlcmd/pull/628) (also see [#111](https://github.com/microsoft/go-sqlcmd/issues/111)) |
+| `-j` | Print raw error messages | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) |
+| `-p[1]` | Print performance statistics after each result set. `-p1` uses colon-separated format for machine parsing | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) |
 
 For historical context and to provide feedback, see [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292).
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Most switches from the original ODBC-based `sqlcmd` have been implemented. The f
 | Switch | Description | Tracking |
 |--------|-------------|----------|
 | `-f` | Input/output code page | proposed in [#628](https://github.com/microsoft/go-sqlcmd/pull/628) (also see [#111](https://github.com/microsoft/go-sqlcmd/issues/111)) |
-| `-j` | Print raw error messages | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) |
-| `-p[1]` | Print performance statistics after each result set. `-p1` uses colon-separated format for machine parsing | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) |
+| `-j` | Print raw error messages | [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292) (earlier attempt: [#624](https://github.com/microsoft/go-sqlcmd/pull/624), closed) |
+| `-p[1]` | Print performance statistics after each result set. `-p1` uses colon-separated format for machine parsing | proposed in [#631](https://github.com/microsoft/go-sqlcmd/pull/631) |
 
 For historical context and to provide feedback, see [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292).
 

--- a/README.md
+++ b/README.md
@@ -162,16 +162,19 @@ The following switches have different behavior in this version of `sqlcmd` compa
 
 ### Switches not available in the new sqlcmd (go-sqlcmd) yet
 
-There are a few switches yet to be implemented in the new `sqlcmd` (go-sqlcmd) compared
-to the original ODBC based `sqlcmd`, discussion [#293](https://github.com/microsoft/go-sqlcmd/discussions/292) 
-lists these switches. Please provide feedback in the discussion on which 
-switches are most important to you to have implemented next in the new sqlcmd.
+Most switches from the original ODBC-based `sqlcmd` have been implemented. The following switches are not yet available:
 
+| Switch | Description |
+|--------|-------------|
+| `-j` | Print raw error messages |
+| `-p[1]` | Print statistics (optional colon format) |
+
+For historical context and to provide feedback, see [discussion #292](https://github.com/microsoft/go-sqlcmd/discussions/292).
 
 ### Miscellaneous enhancements
 
 - Console output coloring (see below)
-- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlAuthentication`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` username parameter.
+- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlAuthentication`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`, `ActiveDirectoryInteractive`, `ActiveDirectoryAzCli`, `ActiveDirectoryDeviceCode`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` username parameter.
 - The new `--driver-logging-level` command line parameter allows you to see traces from the `go-mssqldb` client driver. Use `64` to see all traces.
 - Sqlcmd can now print results using a vertical format. Use the new `--vertical` command line option to set it. It's also controlled by the `SQLCMDFORMAT` scripting variable.
 
@@ -219,7 +222,7 @@ To use AAD auth, you can use one of two command line switches:
 
 `ActiveDirectoryIntegrated`
 
-This method is currently not implemented and will fall back to `ActiveDirectoryDefault`.
+This method uses integrated Windows authentication. On Windows, it uses the current user's credentials. On Linux and macOS, it uses Kerberos authentication (requires a properly configured Kerberos environment).
 
 `ActiveDirectoryPassword`
 
@@ -238,6 +241,26 @@ Use this method when running sqlcmd on an Azure VM that has either a system-assi
 `ActiveDirectoryServicePrincipal`
 
 This method authenticates the provided username as a service principal id and the password as the client secret for the service principal. Provide a username in the form `<service principal id>@<tenant id>`. Set `SQLCMDPASSWORD` variable to the client secret. If using a certificate instead of a client secret, set `AZURE_CLIENT_CERTIFICATE_PATH` environment variable to the path of the certificate file.
+
+`ActiveDirectoryAzCli`
+
+This method uses the Azure CLI to obtain an access token. You must be logged in to Azure CLI (`az login`) before using this method.
+
+`ActiveDirectoryDeviceCode`
+
+This method uses the device code flow for authentication. It displays a code that you enter at https://microsoft.com/devicelogin to authenticate.
+
+#### Additional authentication methods
+
+The following authentication methods are also supported via `--authentication-method`:
+
+- `ActiveDirectoryWorkloadIdentity` - For workload identity federation scenarios
+- `ActiveDirectoryClientAssertion` - For client assertion authentication
+- `ActiveDirectoryAzurePipelines` - For Azure Pipelines service connections
+- `ActiveDirectoryEnvironment` - Uses environment variables for authentication
+- `ActiveDirectoryAzureDeveloperCli` - Uses Azure Developer CLI credentials
+- `ActiveDirectoryServicePrincipalAccessToken` - Uses a pre-obtained access token
+- `SqlPassword` - SQL Server authentication (same as using `-U` and `-P` without `-G`)
 
 #### Environment variables for AAD auth
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For historical context and to provide feedback, see [discussion #292](https://gi
 ### Miscellaneous enhancements
 
 - Console output coloring (see below)
-- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database  - `SqlPassword`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`, `ActiveDirectoryInteractive`, `ActiveDirectoryAzCli`, `ActiveDirectoryDeviceCode`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` username parameter.
+- `:Connect` now has an optional `-G` parameter to select one of the authentication methods for Azure SQL Database: `SqlPassword`, `ActiveDirectoryDefault`, `ActiveDirectoryIntegrated`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryPassword`, `ActiveDirectoryInteractive`, `ActiveDirectoryAzCli`, `ActiveDirectoryDeviceCode`. If `-G` is not provided, either Integrated security or SQL Authentication will be used, dependent on the presence of a `-U` username parameter.
 - The new `--driver-logging-level` command line parameter allows you to see traces from the `go-mssqldb` client driver. Use `64` to see all traces.
 - Sqlcmd can now print results using a vertical format. Use the new `--vertical` command line option to set it. It's also controlled by the `SQLCMDFORMAT` scripting variable.
 
@@ -260,7 +260,7 @@ The following authentication methods are also supported via `--authentication-me
 - `ActiveDirectoryAzurePipelines` - Authenticates using an Azure Pipelines service connection. Requires `client_id@tenant_id` as username. The service connection ID and system access token are read from the `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` and `SYSTEM_ACCESSTOKEN` environment variables (with `AZURESUBSCRIPTION_CLIENT_ID` as a fallback for the client ID); sqlcmd does not expose a way to pass these as connection parameters.
 - `ActiveDirectoryEnvironment` - Selects a credential type automatically based on which `AZURE_*` environment variables are set (client secret, certificate, or username/password).
 - `ActiveDirectoryAzureDeveloperCli` - Uses credentials from `azd auth login` (Azure Developer CLI).
-- `ActiveDirectoryServicePrincipalAccessToken` - Intended to use a pre-obtained bearer token, but sqlcmd does not currently propagate `SQLCMDPASSWORD` (or `-P`) into the connection string for this method, so the token is not passed to the driver. Do not rely on this method until that gap is closed.
+- `ActiveDirectoryServicePrincipalAccessToken` - Intended to use a pre-obtained bearer token. sqlcmd does not currently propagate `SQLCMDPASSWORD` (or `-P`) into the connection string for this method, so the token is not reaching the driver; tracked in [#758](https://github.com/microsoft/go-sqlcmd/issues/758).
 - `SqlPassword` - SQL Server authentication (equivalent to `-U` and `-P` without `-G`).
 
 #### Environment variables for AAD auth


### PR DESCRIPTION
## Summary

Updates the README.md to fix documentation freshness issues and improve accuracy.

## Changes

### Fixed Issues

1. **Discussion link typo**: Fixed link text from #293 to #292 (the link URL was correct but display text was wrong)

2. **Updated 'Switches not available' section**: Reflects current implementation state
   - Most switches from the original discussion have now been implemented: `-e`, `-g`, `-k`, `-t`, `-z`, `-Z`, `-r`, `-X`
   - `-f` (input/output code page), `-j` (raw error messages), and `-p[1]` (print statistics) remain unimplemented
   - Changed from vague text to a clear table of remaining items

3. **Rewrote ActiveDirectoryIntegrated description**: The previous text just said "currently not implemented and will fall back to `ActiveDirectoryDefault`". The fallback is still real (the go-mssqldb driver does not implement true Integrated auth), so the rewrite preserves that fact and explains *why* — the gap is in the driver, not in sqlcmd's wiring. No behavior change.

4. **Added missing authentication methods to `:Connect` -G list**:
   - `ActiveDirectoryInteractive`
   - `ActiveDirectoryAzCli`
   - `ActiveDirectoryDeviceCode`
   - Also replaced `SqlAuthentication` (never a recognized value) with `SqlPassword`

5. **Documented additional authentication methods** that are available via `--authentication-method`:
   - `ActiveDirectoryWorkloadIdentity`
   - `ActiveDirectoryClientAssertion`
   - `ActiveDirectoryAzurePipelines`
   - `ActiveDirectoryEnvironment`
   - `ActiveDirectoryAzureDeveloperCli`
   - `ActiveDirectoryServicePrincipalAccessToken`
   - `SqlPassword`

   For `WorkloadIdentity` and `AzurePipelines`, the docs only mention the supported environment variables and explicitly note that sqlcmd has no mechanism to pass per-connection parameters like `tokenfilepath`, `serviceconnectionid`, or `systemtoken`.

## Related

This addresses documentation freshness issues identified when comparing the README with the actual implementation in `cmd/sqlcmd/sqlcmd.go`, `pkg/sqlcmd/azure_auth.go`, `pkg/sqlcmd/connect.go`, and the Microsoft Learn documentation.

## Depends on

- #756 - `ActiveDirectoryServicePrincipalAccessToken` is currently broken in sqlcmd (the token is not propagated into the connection string). This PR documents the method as functional, which is only accurate once #756 merges. Merge #756 first.

## Testing

Documentation-only change - no functional changes.
