### PR TITLE
fix: prevent nil pointer panic when piping input to sqlcmd (fixes #607)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ sqlcmd
 
 If no current context exists, `sqlcmd` (with no connection parameters) reverts to the original ODBC `sqlcmd` behavior of creating an interactive session to the default local instance on port 1433 using trusted authentication, otherwise it will create an interactive session to the current context.
 
+### Piping input to sqlcmd
+
+You can pipe SQL commands directly to `sqlcmd` from the command line. This is useful for scripting and automation:
+
+**PowerShell:**
+```powershell
+"SELECT @@version" | sqlcmd -S myserver -d mydb -G
+"SELECT name FROM sys.databases" | sqlcmd -S myserver.database.windows.net -d mydb -G
+```
+
+**Bash:**
+```bash
+echo "SELECT @@version" | sqlcmd -S myserver -d mydb -G
+cat myscript.sql | sqlcmd -S myserver -d mydb -G
+```
+
+Note: When piping input, `GO` batch terminators are optional—`sqlcmd` will automatically execute the batch when the input ends. However, you can still include `GO` statements if you want to execute multiple batches.
+
 ## Sqlcmd
 
 The `sqlcmd` project aims to be a complete port of the original ODBC sqlcmd to the `Go` language, utilizing the [go-mssqldb][] driver. For full documentation of the tool and installation instructions, see [go-sqlcmd-utility][].

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -775,6 +775,10 @@ func isConsoleInitializationRequired(connect *sqlcmd.ConnectSettings, args *SQLC
 	} else if iactive {
 		// Interactive mode also requires console
 		needsConsole = true
+	} else if isStdinRedirected && args.InputFile == nil && args.Query == "" && len(args.ChangePasswordAndExit) == 0 {
+		// Stdin is redirected (piped input) and no input file or query specified
+		// We need a console to read from the redirected stdin (fixes #607)
+		needsConsole = true
 	}
 
 	return needsConsole, iactive


### PR DESCRIPTION
## Summary

Fixes #607 - nil pointer dereference when piping input to sqlcmd with ODBC-compatible flags.

## Problem

When running:
```powershell
"select @@servername" | sqlcmd -G -S server.database.windows.net -d mydb
```

A panic occurred in scanNext() due to a nil Console pointer.

## Root Cause

In cmd/sqlcmd/sqlcmd.go, when using ODBC-compat flags with piped stdin, the isConsoleInitializationRequired() function returned false because stdin was detected as redirected and no password was required. This caused sqlcmd.New(nil, ...) to be called with a nil Console.

## Solution

Added a condition in isConsoleInitializationRequired() to return needsConsole = true when stdin is redirected and no input file or query is specified.

## Changes

1. **cmd/sqlcmd/sqlcmd.go** - Added condition for piped stdin
2. **cmd/sqlcmd/stdin_console_test.go** - Added TestPipedInputRequiresConsole test
3. **README.md** - Added documentation section showing how to pipe input to sqlcmd

## Testing

- Unit tests pass
- Manual testing with PowerShell piped input works
- Linter passes