### PR TITLE
fix: remove redundant strings.ToLower in onerrorCommand

### DIFF
--- a/pkg/sqlcmd/commands.go
+++ b/pkg/sqlcmd/commands.go
@@ -569,9 +569,9 @@ func onerrorCommand(s *Sqlcmd, args []string, line uint) error {
 	}
 	params := strings.TrimSpace(args[0])
 
-	if strings.EqualFold(strings.ToLower(params), "exit") {
+	if strings.EqualFold(params, "exit") {
 		s.Connect.ExitOnError = true
-	} else if strings.EqualFold(strings.ToLower(params), "ignore") {
+	} else if strings.EqualFold(params, "ignore") {
 		s.Connect.IgnoreError = true
 		s.Connect.ExitOnError = false
 	} else {


### PR DESCRIPTION
## Problem

The onerrorCommand function has redundant code that makes the codebase harder to read.

## Root Cause

strings.EqualFold is already case-insensitive, so wrapping the first argument with strings.ToLower() is unnecessary.

## Code Change

**Before:**
```go
if strings.EqualFold(strings.ToLower(params), "exit") {
    s.Connect.ExitOnError = true
} else if strings.EqualFold(strings.ToLower(params), "ignore") {
```

**After:**
```go
if strings.EqualFold(params, "exit") {
    s.Connect.ExitOnError = true
} else if strings.EqualFold(params, "ignore") {
```

## Testing

- Build passes: `go build ./...`
- `TestOnErrorCommand` passes with live database connection (10.0.0.8)
