### PR TITLE
ci: pin all GitHub Actions to commit SHAs and add minimal permissions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,17 +4,19 @@ on:
     branches:
       - main
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   golangci-pr:
     name: lint-pr-changes
     runs-on: ubuntu-latest
     steps:
-      # Pinned to commit SHA for supply chain security (CWE-829)
-      # Verify: gh api repos/actions/setup-go/git/ref/tags/v6 --jq '.object.sha'
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25.9'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: golangci-lint
         # Pinned to commit SHA for supply chain security (CWE-829)
         # Verify: gh api repos/golangci/golangci-lint-action/git/ref/tags/v9 --jq '.object.sha'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,13 +5,16 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.25.9'
     - name: Run tests against Linux SQL

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Problem

Several GitHub Actions workflows use unpinned tag references (e.g. \ctions/checkout@v6\) which are vulnerable to supply chain attacks (CWE-829). A compromised tag could inject malicious code into CI runs. Additionally, some workflows lack explicit \permissions\ blocks, granting broader token scope than necessary.

## Solution

- Pin \ctions/checkout\ to \de0fac2e...@v6.0.2\ in golangci-lint, pr-validation, and security workflows
- Pin \ctions/setup-go\ to \4a360112...@v6.4.0\ in pr-validation and security workflows
- Update \ctions/setup-go\ from v6.2.0 to v6.4.0 in golangci-lint
- Add \permissions: contents: read\ to golangci-lint and pr-validation workflows
- Remove stale verify comments from golangci-lint

## Changes

| File | Change |
|------|--------|
| \.github/workflows/golangci-lint.yml\ | Pin checkout to SHA, update setup-go to v6.4.0, add permissions block |
| \.github/workflows/pr-validation.yml\ | Pin checkout and setup-go to SHAs, add permissions block |
| \.github/workflows/security.yml\ | Pin checkout and setup-go to SHAs |

## Testing

- Verified SHAs match latest release tags via \gh api\
- No functional changes to workflow behavior