### PR TITLE
ci: remove docker ecosystem from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,16 +42,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-
-  # Enable version updates for Dockerfile base images
-  - package-ecosystem: "docker"
-    directory: "/.devcontainer"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels:
-      - "dependencies"
-      - "devcontainer"
-    commit-message:
-      prefix: "deps"
-      include: "scope"


### PR DESCRIPTION
The devcontainer Go base image version must match `go.mod`. Dependabot treats the image tag as semver and proposes invalid bumps (e.g. `go:1.25` to `go:2.1`). The `devcontainer-check.yml` CI workflow already guards against version mismatches, so automated Dependabot docker updates add no value here.

Closes #741