### PR TITLE
fix: reject non-YAML extensions for --sqlconfig flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ sqlcmd config connection-strings
 sqlcmd config view
 ```
 
+#### Custom configuration files
+
+The `--sqlconfig` flag specifies a custom configuration file. The file must be YAML. Extensionless filenames are allowed; if the file has an extension, it must be `.yaml` or `.yml`:
+
+```
+sqlcmd config --sqlconfig ./myproject.yaml add-endpoint --name ep1434 --address localhost --port 1434
+sqlcmd config --sqlconfig ./myproject.yaml view
+```
+
 ### Versions
 
 To see all version tags to choose from (2017, 2019, 2022 etc.), and install a specific version, run:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,13 +4,16 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	. "github.com/microsoft/go-sqlcmd/cmd/modern/sqlconfig"
 	"github.com/microsoft/go-sqlcmd/internal/io/file"
 	"github.com/microsoft/go-sqlcmd/internal/io/folder"
 	"github.com/microsoft/go-sqlcmd/internal/pal"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 var config Sqlconfig
@@ -22,6 +25,11 @@ var filename string
 func SetFileName(name string) {
 	if name == "" {
 		panic("name is empty")
+	}
+
+	if ext := strings.ToLower(filepath.Ext(name)); ext != "" && ext != ".yaml" && ext != ".yml" {
+		checkErr(fmt.Errorf("configuration file %q has unsupported extension %q (must be .yaml or .yml)", name, ext))
+		return
 	}
 
 	filename = name

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,15 +4,18 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
 	. "github.com/microsoft/go-sqlcmd/cmd/modern/sqlconfig"
 	"github.com/microsoft/go-sqlcmd/internal/output"
 	"github.com/microsoft/go-sqlcmd/internal/pal"
 	"github.com/microsoft/go-sqlcmd/internal/secret"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"reflect"
-	"strings"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
@@ -378,6 +381,32 @@ func TestConfig_GetCurrentContextEndPointNotFoundPanic(t *testing.T) {
 	assert.Panics(t, func() {
 		CurrentContext()
 	})
+}
+
+func TestSetFileName_RejectsNonYAMLExtension(t *testing.T) {
+	var gotErr error
+	originalCallback := errorCallback
+	errorCallback = func(err error) { gotErr = err }
+	t.Cleanup(func() { errorCallback = originalCallback })
+
+	SetFileName("config.json")
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), ".json")
+
+	gotErr = nil
+	SetFileName("config.toml")
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), ".toml")
+
+	tempDir := t.TempDir()
+
+	gotErr = nil
+	SetFileName(filepath.Join(tempDir, t.Name()+".yaml"))
+	assert.NoError(t, gotErr)
+
+	gotErr = nil
+	SetFileName(filepath.Join(tempDir, t.Name()+".yml"))
+	assert.NoError(t, gotErr)
 }
 
 func TestConfig_DeleteContextThatDoesNotExist(t *testing.T) {


### PR DESCRIPTION
## Problem

`sqlcmd --sqlconfig config.json` silently creates a JSON-named file but writes YAML content, leading to confusing behavior when users reference it later.

Fixes #690, Fixes #597

## Root Cause

No extension validation in `config.SetFileName()`.

## Solution

- Validate file extension in `SetFileName()` before proceeding
- Reject extensions other than `.yaml` or `.yml` (extensionless files like the default `~/.sqlcmd/sqlconfig` are still allowed)
- Report via `checkErr` (consistent with existing error patterns in this package)

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Extension validation in `SetFileName` |
| `internal/config/config_test.go` | Tests for rejected and accepted extensions |
| `README.md` | Document custom config file extension requirement |

## Testing

- `go build ./cmd/modern` passes
- `go test ./internal/config/...` passes
- New `TestSetFileName_RejectsNonYAMLExtension` verifies `.json`/`.toml` rejected and `.yaml`/`.yml` accepted