### PR TITLE
deps: bump go to 1.25.10 to fix GO-2026-4971 and GO-2026-4918

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: golangci-lint
         # Pinned to commit SHA for supply chain security (CWE-829)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: '1.25.9'
+        go-version: '1.25.10'
     - name: Run tests against Linux SQL
       run: |
         go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/go-sqlcmd
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/alecthomas/chroma/v2 v2.24.1


### PR DESCRIPTION
## Problem

Govulncheck is failing on PRs (e.g. #751) with two stdlib vulnerabilities present in go 1.25.9:

- **GO-2026-4971** -- panic in `net.Dial`/`LookupPort` on Windows when handling NUL byte. Fixed in `net@go1.25.10`.
- **GO-2026-4918** -- infinite loop in `net/http` HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE`. Fixed in `net/http@go1.25.10`.

## Root Cause

The Go toolchain version (`go.mod` directive and `go-version` inputs in workflows) is hardcoded as `1.25.9` and is not maintained by Dependabot:

- The `gomod` ecosystem does not update the `go` directive.
- The `github-actions` ecosystem does not update arbitrary `with:` string inputs like `go-version`.

So nobody bumps these. Stdlib CVEs require manually advancing the toolchain.

## Solution

Bump the toolchain patch version from `1.25.9` to `1.25.10` in:

- `go.mod`
- `.github/workflows/pr-validation.yml`
- `.github/workflows/golangci-lint.yml`

Staying on the `1.25` minor line to keep the change minimal. The devcontainer Dockerfile only pins the major.minor (`1.25`), so the version-alignment check still passes without changes there.

## Changes

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.9` -> `go 1.25.10` |
| `.github/workflows/pr-validation.yml` | `go-version: '1.25.9'` -> `'1.25.10'` |
| `.github/workflows/golangci-lint.yml` | `go-version: '1.25.9'` -> `'1.25.10'` |

## Testing

- `go build ./...` passes locally with the auto-downloaded `go1.25.10` toolchain.
- Govulncheck on this branch should now report no stdlib calls affected.

## Related

- Unblocks #751 (Dependabot golang-x bump) and any other PR currently failing the Go Vulnerability Check.
