### PR TITLE
fix: use ActiveDirectoryDefault for -G with no username

### DIFF
--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -203,7 +203,8 @@ func (a SQLCmdArguments) authenticationMethod(hasPassword bool) string {
 	if a.UseAad {
 		switch {
 		case a.UserName == "":
-			return azuread.ActiveDirectoryIntegrated
+			// Default walks the Azure credential chain; works in non-interactive shells (issue #699).
+			return azuread.ActiveDirectoryDefault
 		case hasPassword:
 			return azuread.ActiveDirectoryPassword
 		default:

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -519,6 +519,26 @@ func TestConditionsForPasswordPrompt(t *testing.T) {
 	}
 }
 
+func TestAuthenticationMethodForUseAad(t *testing.T) {
+	tests := []struct {
+		name        string
+		userName    string
+		hasPassword bool
+		expected    string
+	}{
+		{"-G no username picks Default", "", false, azuread.ActiveDirectoryDefault},
+		{"-G no username, password ignored", "", true, azuread.ActiveDirectoryDefault},
+		{"-G with username, no password picks Interactive", "user@contoso", false, azuread.ActiveDirectoryInteractive},
+		{"-G with username and password picks Password", "user@contoso", true, azuread.ActiveDirectoryPassword},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := SQLCmdArguments{UseAad: true, UserName: tc.userName}
+			assert.Equal(t, tc.expected, a.authenticationMethod(tc.hasPassword))
+		})
+	}
+}
+
 func TestStartupScript(t *testing.T) {
 	o, err := os.CreateTemp("", "sqlcmdmain")
 	assert.NoError(t, err, "os.CreateTemp")


### PR DESCRIPTION
## Problem

`sqlcmd -G` with no username fails in non-interactive contexts (e.g. Emacs inferior shells, CI jobs) with:

```
mssql: login error: Integrated Security not supported.
```
Reported in #699.

## Root Cause

`authenticationMethod()` selects `ActiveDirectoryIntegrated` for `-G` + no username. SSPI Integrated auth requires an interactive Windows logon token, which is unavailable in Emacs inferior processes, detached sessions, and Linux/macOS shells. The existing `-G` help text already documents the intended behavior as `ActiveDirectoryDefault` -- the code was the bug.

## Solution

Select `ActiveDirectoryDefault` instead, which walks the standard Azure credential chain (env vars, managed identity, Azure CLI, VS, then interactive browser) and works on all platforms. Users who specifically need SSPI can pass `--authentication-method=ActiveDirectoryIntegrated` explicitly.

## Changes

| File | Change |
|------|--------|
| `cmd/sqlcmd/sqlcmd.go` | Return `ActiveDirectoryDefault` instead of `ActiveDirectoryIntegrated` for `-G` with no username |
| `cmd/sqlcmd/sqlcmd_test.go` | `TestAuthenticationMethodForUseAad` pins the four `-G` branches |

## Testing

- New test `TestAuthenticationMethodForUseAad` covers all four `-G` branches.
- Full `./cmd/sqlcmd/...` suite green against live SQL Server.

## Related Issues

Fixes #699