### PR TITLE
feat: implement -j raw-errors flag for ODBC sqlcmd compatibility

### DIFF
--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -83,6 +83,7 @@ type SQLCmdArguments struct {
 	ChangePasswordAndExit       string
 	TraceFile                   string
 	ServerNameOverride          string
+	RawErrors                   bool
 	// Keep Help at the end of the list
 	Help  bool
 	Ascii bool
@@ -487,6 +488,7 @@ func setFlags(rootCmd *cobra.Command, args *SQLCmdArguments) {
 	rootCmd.Flags().IntVar(&args.DriverLoggingLevel, "driver-logging-level", 0, localizer.Sprintf("Level of mssql driver messages to print"))
 	rootCmd.Flags().BoolVarP(&args.ExitOnError, "exit-on-error", "b", false, localizer.Sprintf("Specifies that sqlcmd exits and returns a %s value when an error occurs", localizer.DosErrorLevel))
 	rootCmd.Flags().IntVarP(&args.ErrorLevel, "error-level", "m", 0, localizer.Sprintf("Controls which error messages are sent to %s. Messages that have severity level greater than or equal to this level are sent", localizer.StdoutName))
+	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Prints raw error messages from the SQL Server driver without removing the driver-supplied prefix from the message text"))
 
 	//Need to decide on short of Header , as "h" is already used in help command in Cobra
 	rootCmd.Flags().IntVarP(&args.Headers, "headers", "h", 0, localizer.Sprintf("Specifies the number of rows to print between the column headings. Use -h-1 to specify that headers not be printed"))
@@ -871,7 +873,7 @@ func run(vars *sqlcmd.Variables, args *SQLCmdArguments) (int, error) {
 	}
 
 	s.Connect = &connectConfig
-	s.Format = sqlcmd.NewSQLCmdDefaultFormatter(vars, args.TrimSpaces, args.getControlCharacterBehavior())
+	s.Format = sqlcmd.NewSQLCmdDefaultFormatter(vars, args.TrimSpaces, args.getControlCharacterBehavior(), sqlcmd.WithRawErrors(args.RawErrors))
 	if args.OutputFile != "" {
 		err = s.RunCommand(s.Cmd["OUT"], []string{args.OutputFile})
 		if err != nil {

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -488,7 +488,7 @@ func setFlags(rootCmd *cobra.Command, args *SQLCmdArguments) {
 	rootCmd.Flags().IntVar(&args.DriverLoggingLevel, "driver-logging-level", 0, localizer.Sprintf("Level of mssql driver messages to print"))
 	rootCmd.Flags().BoolVarP(&args.ExitOnError, "exit-on-error", "b", false, localizer.Sprintf("Specifies that sqlcmd exits and returns a %s value when an error occurs", localizer.DosErrorLevel))
 	rootCmd.Flags().IntVarP(&args.ErrorLevel, "error-level", "m", 0, localizer.Sprintf("Controls which error messages are sent to %s. Messages that have severity level greater than or equal to this level are sent", localizer.StdoutName))
-	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Keep the \"mssql: \" prefix that go-mssqldb adds to error messages"))
+	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Do not strip the \"mssql: \" prefix from error messages"))
 
 	//Need to decide on short of Header , as "h" is already used in help command in Cobra
 	rootCmd.Flags().IntVarP(&args.Headers, "headers", "h", 0, localizer.Sprintf("Specifies the number of rows to print between the column headings. Use -h-1 to specify that headers not be printed"))

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -488,7 +488,7 @@ func setFlags(rootCmd *cobra.Command, args *SQLCmdArguments) {
 	rootCmd.Flags().IntVar(&args.DriverLoggingLevel, "driver-logging-level", 0, localizer.Sprintf("Level of mssql driver messages to print"))
 	rootCmd.Flags().BoolVarP(&args.ExitOnError, "exit-on-error", "b", false, localizer.Sprintf("Specifies that sqlcmd exits and returns a %s value when an error occurs", localizer.DosErrorLevel))
 	rootCmd.Flags().IntVarP(&args.ErrorLevel, "error-level", "m", 0, localizer.Sprintf("Controls which error messages are sent to %s. Messages that have severity level greater than or equal to this level are sent", localizer.StdoutName))
-	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Prints error messages exactly as returned by the go-mssqldb client driver, without stripping its \"mssql: \" prefix"))
+	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Keep the \"mssql: \" prefix that go-mssqldb adds to error messages"))
 
 	//Need to decide on short of Header , as "h" is already used in help command in Cobra
 	rootCmd.Flags().IntVarP(&args.Headers, "headers", "h", 0, localizer.Sprintf("Specifies the number of rows to print between the column headings. Use -h-1 to specify that headers not be printed"))

--- a/cmd/sqlcmd/sqlcmd.go
+++ b/cmd/sqlcmd/sqlcmd.go
@@ -488,7 +488,7 @@ func setFlags(rootCmd *cobra.Command, args *SQLCmdArguments) {
 	rootCmd.Flags().IntVar(&args.DriverLoggingLevel, "driver-logging-level", 0, localizer.Sprintf("Level of mssql driver messages to print"))
 	rootCmd.Flags().BoolVarP(&args.ExitOnError, "exit-on-error", "b", false, localizer.Sprintf("Specifies that sqlcmd exits and returns a %s value when an error occurs", localizer.DosErrorLevel))
 	rootCmd.Flags().IntVarP(&args.ErrorLevel, "error-level", "m", 0, localizer.Sprintf("Controls which error messages are sent to %s. Messages that have severity level greater than or equal to this level are sent", localizer.StdoutName))
-	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Prints raw error messages from the SQL Server driver without removing the driver-supplied prefix from the message text"))
+	rootCmd.Flags().BoolVarP(&args.RawErrors, "raw-errors", "j", false, localizer.Sprintf("Prints error messages exactly as returned by the go-mssqldb client driver, without stripping its \"mssql: \" prefix"))
 
 	//Need to decide on short of Header , as "h" is already used in help command in Cobra
 	rootCmd.Flags().IntVarP(&args.Headers, "headers", "h", 0, localizer.Sprintf("Specifies the number of rows to print between the column headings. Use -h-1 to specify that headers not be printed"))

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -123,6 +123,9 @@ func TestValidCommandLineToArgsConversion(t *testing.T) {
 		{[]string{"-N", "true", "-J", "/path/to/cert2.pem"}, func(args SQLCmdArguments) bool {
 			return args.EncryptConnection == "true" && args.ServerCertificate == "/path/to/cert2.pem"
 		}},
+		{[]string{"-j"}, func(args SQLCmdArguments) bool {
+			return args.RawErrors
+		}},
 	}
 
 	for _, test := range commands {

--- a/cmd/sqlcmd/sqlcmd_test.go
+++ b/cmd/sqlcmd/sqlcmd_test.go
@@ -126,6 +126,9 @@ func TestValidCommandLineToArgsConversion(t *testing.T) {
 		{[]string{"-j"}, func(args SQLCmdArguments) bool {
 			return args.RawErrors
 		}},
+		{[]string{"--raw-errors"}, func(args SQLCmdArguments) bool {
+			return args.RawErrors
+		}},
 	}
 
 	for _, test := range commands {

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -92,10 +92,11 @@ type sqlCmdFormatterType struct {
 type FormatterOption func(*sqlCmdFormatterType)
 
 // WithRawErrors controls the -j "raw error messages" behavior. When enabled,
-// the driver-supplied error text is emitted verbatim (the "mssql: " prefix
-// that go-mssqldb prepends is not stripped). The Msg/Level/State/Server
-// header and screen-width wrapping are unaffected, matching the ODBC sqlcmd -j
-// implementation, which also only suppresses driver-prefix stripping.
+// the error string returned by the go-mssqldb client driver is emitted verbatim
+// (the "mssql: " prefix that go-mssqldb's mssql.Error.Error() prepends is not
+// stripped). The Msg/Level/State/Server header and screen-width wrapping are
+// unaffected, matching the ODBC sqlcmd -j implementation, which likewise only
+// suppresses the prefix strip.
 func WithRawErrors(raw bool) FormatterOption {
 	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -114,7 +114,9 @@ func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb C
 		ccb:                  ccb,
 	}
 	for _, opt := range opts {
-		opt(f)
+		if opt != nil {
+			opt(f)
+		}
 	}
 	return f
 }

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -91,8 +91,9 @@ type sqlCmdFormatterType struct {
 // FormatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
 type FormatterOption func(*sqlCmdFormatterType)
 
-// WithRawErrors implements -j: when raw is true, AddError keeps the "mssql: "
-// prefix that go-mssqldb adds to error text instead of stripping it.
+// WithRawErrors controls AddError prefix handling: when raw is true, AddError
+// keeps the "mssql: " prefix that go-mssqldb adds to error text instead of
+// stripping it.
 func WithRawErrors(raw bool) FormatterOption {
 	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -88,20 +88,19 @@ type sqlCmdFormatterType struct {
 	rawErrors            bool
 }
 
-// formatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
-// The type is unexported so options must come from helpers in this package.
-type formatterOption func(*sqlCmdFormatterType)
+// FormatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
+type FormatterOption func(*sqlCmdFormatterType)
 
 // WithRawErrors implements -j: when raw is true, AddError keeps the "mssql: "
 // prefix that go-mssqldb adds to error text instead of stripping it.
-func WithRawErrors(raw bool) formatterOption {
+func WithRawErrors(raw bool) FormatterOption {
 	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }
 
 // NewSQLCmdDefaultFormatter returns a Formatter based on the configuration.
 // It returns an ASCII formatter if the format is set to "ascii", otherwise it returns a formatter that mimics the original ODBC-based sqlcmd formatter.
-// formatterOption values (e.g. WithRawErrors) apply only to the ODBC-mimicking formatter; the ASCII formatter ignores them.
-func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...formatterOption) Formatter {
+// FormatterOption values (e.g. WithRawErrors) apply only to the ODBC-mimicking formatter; the ASCII formatter ignores them.
+func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...FormatterOption) Formatter {
 	if vars.Format() == "ascii" {
 		return NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb)
 	}

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -88,20 +88,17 @@ type sqlCmdFormatterType struct {
 	rawErrors            bool
 }
 
-// FormatterOption customizes the default formatter built by NewSQLCmdDefaultFormatter.
-// Use the provided With* constructors (e.g. WithRawErrors) to supply options.
+// FormatterOption customizes the formatter returned by NewSQLCmdDefaultFormatter.
 type FormatterOption func(*sqlCmdFormatterType)
 
-// WithRawErrors controls AddError prefix handling: when raw is true, AddError
-// keeps the "mssql: " prefix that go-mssqldb adds to error text instead of
-// stripping it.
+// WithRawErrors makes AddError preserve the "mssql: " prefix that go-mssqldb
+// adds to error text instead of stripping it.
 func WithRawErrors(raw bool) FormatterOption {
 	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }
 
-// NewSQLCmdDefaultFormatter returns a Formatter based on the configuration.
-// It returns an ASCII formatter if the format is set to "ascii", otherwise it returns a formatter that mimics the original ODBC-based sqlcmd formatter.
-// Any FormatterOption values (e.g. WithRawErrors) are applied to the returned formatter.
+// NewSQLCmdDefaultFormatter returns an ASCII formatter when SQLCMDFORMAT is "ascii",
+// otherwise a formatter that mimics the original ODBC-based sqlcmd formatter.
 func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...FormatterOption) Formatter {
 	if vars.Format() == "ascii" {
 		f := NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb).(*asciiFormatter)

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -91,12 +91,8 @@ type sqlCmdFormatterType struct {
 // FormatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
 type FormatterOption func(*sqlCmdFormatterType)
 
-// WithRawErrors controls the -j "raw error messages" behavior. When enabled,
-// the error string returned by the go-mssqldb client driver is emitted verbatim
-// (the "mssql: " prefix that go-mssqldb's mssql.Error.Error() prepends is not
-// stripped). The Msg/Level/State/Server header and screen-width wrapping are
-// unaffected, matching the ODBC sqlcmd -j implementation, which likewise only
-// suppresses the prefix strip.
+// WithRawErrors implements -j: when raw is true, AddError keeps the "mssql: "
+// prefix that go-mssqldb adds to error text instead of stripping it.
 func WithRawErrors(raw bool) FormatterOption {
 	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -85,20 +85,38 @@ type sqlCmdFormatterType struct {
 	maxColNameLen        int
 	colorizer            color.Colorizer
 	xml                  bool
+	rawErrors            bool
+}
+
+// FormatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
+type FormatterOption func(*sqlCmdFormatterType)
+
+// WithRawErrors controls the -j "raw error messages" behavior. When enabled,
+// the driver-supplied error text is emitted verbatim (the "mssql: " prefix
+// that go-mssqldb prepends is not stripped). The Msg/Level/State/Server
+// header and screen-width wrapping are unaffected, matching the ODBC sqlcmd -j
+// implementation, which also only suppresses driver-prefix stripping.
+func WithRawErrors(raw bool) FormatterOption {
+	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }
 
 // NewSQLCmdDefaultFormatter returns a Formatter based on the configuration.
 // It returns an ASCII formatter if the format is set to "ascii", otherwise it returns a formatter that mimics the original ODBC-based sqlcmd formatter.
-func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior) Formatter {
+// FormatterOption values (e.g. WithRawErrors) apply only to the ODBC-mimicking formatter; the ASCII formatter ignores them.
+func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...FormatterOption) Formatter {
 	if vars.Format() == "ascii" {
 		return NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb)
 	}
-	return &sqlCmdFormatterType{
+	f := &sqlCmdFormatterType{
 		removeTrailingSpaces: removeTrailingSpaces,
 		format:               "horizontal",
 		colorizer:            color.New(false),
 		ccb:                  ccb,
 	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
 }
 
 // Adds the given string to the current line, wrapping it based on the screen width setting
@@ -232,7 +250,9 @@ func (f *sqlCmdFormatterType) AddError(err error) {
 			} else {
 				b.WriteString(localizer.Sprintf("Msg %#v, Level %d, State %d, Server %s, Line %#v%s", e.Number, e.Class, e.State, e.ServerName, e.LineNo, SqlcmdEol))
 			}
-			msg = strings.TrimPrefix(msg, "mssql: ")
+			if !f.rawErrors {
+				msg = strings.TrimPrefix(msg, "mssql: ")
+			}
 		}
 	}
 	if print {

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -88,7 +88,8 @@ type sqlCmdFormatterType struct {
 	rawErrors            bool
 }
 
-// FormatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
+// FormatterOption customizes the default formatter built by NewSQLCmdDefaultFormatter.
+// Use the provided With* constructors (e.g. WithRawErrors) to supply options.
 type FormatterOption func(*sqlCmdFormatterType)
 
 // WithRawErrors controls AddError prefix handling: when raw is true, AddError
@@ -100,7 +101,7 @@ func WithRawErrors(raw bool) FormatterOption {
 
 // NewSQLCmdDefaultFormatter returns a Formatter based on the configuration.
 // It returns an ASCII formatter if the format is set to "ascii", otherwise it returns a formatter that mimics the original ODBC-based sqlcmd formatter.
-// FormatterOption values (e.g. WithRawErrors) apply only to the ODBC-mimicking formatter; the ASCII formatter ignores them.
+// Any FormatterOption values passed via opts (e.g. WithRawErrors) are applied to the ODBC-mimicking formatter; the ASCII formatter ignores them.
 func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...FormatterOption) Formatter {
 	if vars.Format() == "ascii" {
 		return NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb)

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -101,10 +101,12 @@ func WithRawErrors(raw bool) FormatterOption {
 
 // NewSQLCmdDefaultFormatter returns a Formatter based on the configuration.
 // It returns an ASCII formatter if the format is set to "ascii", otherwise it returns a formatter that mimics the original ODBC-based sqlcmd formatter.
-// Any FormatterOption values passed via opts (e.g. WithRawErrors) are applied to the ODBC-mimicking formatter; the ASCII formatter ignores them.
+// Any FormatterOption values (e.g. WithRawErrors) are applied to the returned formatter.
 func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...FormatterOption) Formatter {
 	if vars.Format() == "ascii" {
-		return NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb)
+		f := NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb).(*asciiFormatter)
+		applyFormatterOptions(f.sqlCmdFormatterType, opts)
+		return f
 	}
 	f := &sqlCmdFormatterType{
 		removeTrailingSpaces: removeTrailingSpaces,
@@ -112,12 +114,16 @@ func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb C
 		colorizer:            color.New(false),
 		ccb:                  ccb,
 	}
+	applyFormatterOptions(f, opts)
+	return f
+}
+
+func applyFormatterOptions(f *sqlCmdFormatterType, opts []FormatterOption) {
 	for _, opt := range opts {
 		if opt != nil {
 			opt(f)
 		}
 	}
-	return f
 }
 
 // Adds the given string to the current line, wrapping it based on the screen width setting

--- a/pkg/sqlcmd/format.go
+++ b/pkg/sqlcmd/format.go
@@ -88,19 +88,20 @@ type sqlCmdFormatterType struct {
 	rawErrors            bool
 }
 
-// FormatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
-type FormatterOption func(*sqlCmdFormatterType)
+// formatterOption configures a Formatter returned by NewSQLCmdDefaultFormatter.
+// The type is unexported so options must come from helpers in this package.
+type formatterOption func(*sqlCmdFormatterType)
 
 // WithRawErrors implements -j: when raw is true, AddError keeps the "mssql: "
 // prefix that go-mssqldb adds to error text instead of stripping it.
-func WithRawErrors(raw bool) FormatterOption {
+func WithRawErrors(raw bool) formatterOption {
 	return func(f *sqlCmdFormatterType) { f.rawErrors = raw }
 }
 
 // NewSQLCmdDefaultFormatter returns a Formatter based on the configuration.
 // It returns an ASCII formatter if the format is set to "ascii", otherwise it returns a formatter that mimics the original ODBC-based sqlcmd formatter.
-// FormatterOption values (e.g. WithRawErrors) apply only to the ODBC-mimicking formatter; the ASCII formatter ignores them.
-func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...FormatterOption) Formatter {
+// formatterOption values (e.g. WithRawErrors) apply only to the ODBC-mimicking formatter; the ASCII formatter ignores them.
+func NewSQLCmdDefaultFormatter(vars *Variables, removeTrailingSpaces bool, ccb ControlCharacterBehavior, opts ...formatterOption) Formatter {
 	if vars.Format() == "ascii" {
 		return NewSQLCmdAsciiFormatter(vars, removeTrailingSpaces, ccb)
 	}

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/microsoft/go-sqlcmd/internal/color"
 	"github.com/stretchr/testify/assert"
 )
@@ -161,4 +162,44 @@ func TestFormatterXmlMode(t *testing.T) {
 	err := runSqlCmd(t, s, []string{"select name from sys.databases where name='master' for xml auto ", "GO"})
 	assert.NoError(t, err, "runSqlCmd returned error")
 	assert.Equal(t, `<sys.databases name="master"/>`+SqlcmdEol, buf.buf.String())
+}
+
+func TestAddErrorRawErrors(t *testing.T) {
+	mssqlErr := mssql.Error{
+		Number:     50000,
+		State:      1,
+		Class:      16,
+		Message:    "Something failed",
+		ServerName: "server",
+		LineNo:     7,
+	}
+
+	tests := []struct {
+		name      string
+		rawErrors bool
+	}{
+		{name: "default strips mssql prefix", rawErrors: false},
+		{name: "raw preserves mssql prefix", rawErrors: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := new(strings.Builder)
+			errOut := new(strings.Builder)
+			vars := InitializeVariables(false)
+			f := NewSQLCmdDefaultFormatter(vars, false, ControlIgnore, WithRawErrors(tc.rawErrors))
+			f.BeginBatch("", vars, out, errOut)
+
+			f.AddError(mssqlErr)
+
+			got := errOut.String()
+			assert.Contains(t, got, "Msg 50000, Level 16, State 1, Server server, Line 7", "header should always be printed")
+			assert.Contains(t, got, "Something failed", "message body should always be printed")
+			if tc.rawErrors {
+				assert.Contains(t, got, "mssql: Something failed", "raw mode preserves the driver-supplied prefix")
+			} else {
+				assert.NotContains(t, got, "mssql: ", "default mode strips the driver-supplied prefix")
+			}
+		})
+	}
 }

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -164,42 +164,29 @@ func TestFormatterXmlMode(t *testing.T) {
 	assert.Equal(t, `<sys.databases name="master"/>`+SqlcmdEol, buf.buf.String())
 }
 
-func TestAddErrorRawErrors(t *testing.T) {
-	mssqlErr := mssql.Error{
-		Number:     50000,
-		State:      1,
-		Class:      16,
-		Message:    "Something failed",
-		ServerName: "server",
-		LineNo:     7,
-	}
+func TestAddErrorStripsMssqlPrefixByDefault(t *testing.T) {
+	out, errOut := new(strings.Builder), new(strings.Builder)
+	vars := InitializeVariables(false)
+	f := NewSQLCmdDefaultFormatter(vars, false, ControlIgnore)
+	f.BeginBatch("", vars, out, errOut)
 
-	tests := []struct {
-		name      string
-		rawErrors bool
-	}{
-		{name: "default strips mssql prefix", rawErrors: false},
-		{name: "raw preserves mssql prefix", rawErrors: true},
-	}
+	f.AddError(mssql.Error{Number: 50000, State: 1, Class: 16, Message: "Something failed", ServerName: "server", LineNo: 7})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			out := new(strings.Builder)
-			errOut := new(strings.Builder)
-			vars := InitializeVariables(false)
-			f := NewSQLCmdDefaultFormatter(vars, false, ControlIgnore, WithRawErrors(tc.rawErrors))
-			f.BeginBatch("", vars, out, errOut)
+	got := errOut.String()
+	assert.Contains(t, got, "Msg 50000, Level 16, State 1, Server server, Line 7")
+	assert.Contains(t, got, "Something failed")
+	assert.NotContains(t, got, "mssql: Something failed")
+}
 
-			f.AddError(mssqlErr)
+func TestAddErrorWithRawErrorsKeepsMssqlPrefix(t *testing.T) {
+	out, errOut := new(strings.Builder), new(strings.Builder)
+	vars := InitializeVariables(false)
+	f := NewSQLCmdDefaultFormatter(vars, false, ControlIgnore, WithRawErrors(true))
+	f.BeginBatch("", vars, out, errOut)
 
-			got := errOut.String()
-			assert.Contains(t, got, "Msg 50000, Level 16, State 1, Server server, Line 7", "header should always be printed")
-			assert.Contains(t, got, "Something failed", "message body should always be printed")
-			if tc.rawErrors {
-				assert.Contains(t, got, "mssql: Something failed", "raw mode preserves the driver-supplied prefix")
-			} else {
-				assert.NotContains(t, got, "mssql: ", "default mode strips the driver-supplied prefix")
-			}
-		})
-	}
+	f.AddError(mssql.Error{Number: 50000, State: 1, Class: 16, Message: "Something failed", ServerName: "server", LineNo: 7})
+
+	got := errOut.String()
+	assert.Contains(t, got, "Msg 50000, Level 16, State 1, Server server, Line 7")
+	assert.Contains(t, got, "mssql: Something failed")
 }

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -191,8 +191,6 @@ func TestAddErrorWithRawErrorsKeepsMssqlPrefix(t *testing.T) {
 	assert.Contains(t, got, "mssql: Something failed")
 }
 
-// TestAddErrorWithRawErrorsAppliesToAsciiFormatter guards against silently dropping
-// FormatterOption values when the caller has selected the ascii result format.
 func TestAddErrorWithRawErrorsAppliesToAsciiFormatter(t *testing.T) {
 	out, errOut := new(strings.Builder), new(strings.Builder)
 	vars := InitializeVariables(false)

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -175,7 +175,7 @@ func TestAddErrorStripsMssqlPrefixByDefault(t *testing.T) {
 	got := errOut.String()
 	assert.Contains(t, got, "Msg 50000, Level 16, State 1, Server server, Line 7")
 	assert.Contains(t, got, "Something failed")
-	assert.NotContains(t, got, "mssql: Something failed")
+	assert.NotContains(t, got, "mssql:")
 }
 
 func TestAddErrorWithRawErrorsKeepsMssqlPrefix(t *testing.T) {

--- a/pkg/sqlcmd/format_test.go
+++ b/pkg/sqlcmd/format_test.go
@@ -190,3 +190,17 @@ func TestAddErrorWithRawErrorsKeepsMssqlPrefix(t *testing.T) {
 	assert.Contains(t, got, "Msg 50000, Level 16, State 1, Server server, Line 7")
 	assert.Contains(t, got, "mssql: Something failed")
 }
+
+// TestAddErrorWithRawErrorsAppliesToAsciiFormatter guards against silently dropping
+// FormatterOption values when the caller has selected the ascii result format.
+func TestAddErrorWithRawErrorsAppliesToAsciiFormatter(t *testing.T) {
+	out, errOut := new(strings.Builder), new(strings.Builder)
+	vars := InitializeVariables(false)
+	vars.Set(SQLCMDFORMAT, "ascii")
+	f := NewSQLCmdDefaultFormatter(vars, false, ControlIgnore, WithRawErrors(true))
+	f.BeginBatch("", vars, out, errOut)
+
+	f.AddError(mssql.Error{Number: 50000, State: 1, Class: 16, Message: "Something failed", ServerName: "server", LineNo: 7})
+
+	assert.Contains(t, errOut.String(), "mssql: Something failed", "ascii formatter must honor WithRawErrors")
+}


### PR DESCRIPTION
## Problem

`go-sqlcmd` did not implement the `-j` switch from the ODBC-based `sqlcmd`, which is required to preserve raw driver-supplied error text. This was tracked in discussion [#292](https://github.com/microsoft/go-sqlcmd/discussions/292) as a gap blocking ODBC `sqlcmd` retirement.

## Root Cause

The default formatter (`pkg/sqlcmd/format.go`) unconditionally stripped the `"mssql: "` prefix that `go-mssqldb` prepends to every `mssql.Error.Error()` string. There was no way for a caller to opt out, and no CLI flag exposed the behavior.

## Solution

Implement `-j` / `--raw-errors` with semantics that match the ODBC reference (`Sql/utils/sqlcmd/console/src/Formatter.cpp`, gated on `m_PrintRawErrorMessages`):

- When `-j` is set, the driver-supplied prefix is preserved verbatim.
- The `Msg N, Level N, State N, Server S, Line N` header is **always** emitted (matches ODBC).
- Screen-width wrapping via `fitToScreen` is **always** applied (matches ODBC).

The formatter is extended via a non-breaking variadic functional-options pattern, so existing callers (including `internal/sql/mssql.go`) compile unchanged.

## Changes

| File | Change |
| --- | --- |
| `pkg/sqlcmd/format.go` | Add `rawErrors` field, `FormatterOption` type, `WithRawErrors`; gate `strings.TrimPrefix(msg, "mssql: ")` in `AddError`. |
| `pkg/sqlcmd/format_test.go` | Add `TestAddErrorStripsMssqlPrefixByDefault` and `TestAddErrorWithRawErrorsKeepsMssqlPrefix` — two parallel tests, each readable end-to-end, covering both gate states. |
| `cmd/sqlcmd/sqlcmd.go` | Add `RawErrors` to `SQLCmdArguments`; register `-j` / `--raw-errors`; pass `WithRawErrors` into the formatter. |
| `cmd/sqlcmd/sqlcmd_test.go` | Add `-j` case to `TestValidCommandLineToArgsConversion`. |

## Testing

- `go build ./...` clean.
- `go vet ./...` clean (only pre-existing credman warnings on `windows/v0.21.0`).
- `go test ./pkg/sqlcmd/ ./cmd/sqlcmd/ -count=1` against a live SQL Server: PASS.
- The two `TestAddError…` tests assert the header and message body appear in both modes and that the `"mssql: "` prefix is stripped exactly when `-j` is unset (would fail in either direction if the gate logic regressed).

## Related Issues

Closes the `-j` gap in discussion [#292](https://github.com/microsoft/go-sqlcmd/discussions/292).

