### PR TITLE
deps: bump chroma to v2.25.0 and align devcontainer to Go 1.26

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # GOTOOLCHAIN=auto lets Go download the exact patch version (e.g. 1.25.9)
 # when the base image is slightly behind. Downloads are verified against
 # sum.golang.org.
-FROM mcr.microsoft.com/devcontainers/go:1.25-bookworm
+FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
 ENV GOTOOLCHAIN=auto
 
 # The base image sets GOPATH=/go owned by root. Override to a user-writable

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.26.0'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: golangci-lint
         # Pinned to commit SHA for supply chain security (CWE-829)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: '1.25.10'
+        go-version: '1.26.0'
     - name: Run tests against Linux SQL
       run: |
         go version

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/microsoft/go-sqlcmd
 
-go 1.25.10
+go 1.26
 
 require (
-	github.com/alecthomas/chroma/v2 v2.24.1
+	github.com/alecthomas/chroma/v2 v2.25.0
 	github.com/billgraziano/dpapi v0.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
@@ -39,7 +39,7 @@ require (
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dlclark/regexp2 v1.12.0 // indirect
+	github.com/dlclark/regexp2/v2 v2.1.0 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6DfZJQM=
-github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
+github.com/alecthomas/chroma/v2 v2.25.0 h1:DWkVlxrNpxPf+Qcfe04LBqUArxUiybK8ZQ9T7OFu68E=
+github.com/alecthomas/chroma/v2 v2.25.0/go.mod h1:+95AZrRWlpW9g6qXD7S7UdHviopsGP/kCIrtJcU3QoQ=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -43,8 +43,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
-github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2/v2 v2.1.0 h1:jHXRmHRZGbuQzDZjMlCAXOvQb75iv3HyLDzXGj5H1AY=
+github.com/dlclark/regexp2/v2 v2.1.0/go.mod h1:Bz5TMy5d8fPK0ximH0Yi9KvsRHNnvXqUx9XG6a4wB+I=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=


### PR DESCRIPTION
# Problem

PR #762 (dependabot bump of `github.com/alecthomas/chroma/v2` from 2.24.1 to 2.25.0) fails the new `check-go-version-alignment` job:

```
go.mod requires:        go 1.26 (major.minor: 1.26)
Dockerfile base image:  go:1.25
ERROR: Version mismatch!
```

# Root Cause

chroma v2.25.0's own `go.mod` requires Go 1.26, which causes `go mod tidy` to raise our `go` directive from `1.25.10` to `1.26`. The alignment workflow then catches that `.devcontainer/Dockerfile` is still pinned to `mcr.microsoft.com/devcontainers/go:1.25-bookworm`. Dependabot bumps deps but does not edit the Dockerfile, so the check stays red.

# Solution

Update `.devcontainer/Dockerfile` to `go:1.26-bookworm` alongside the chroma bump in a single PR, so both `go.mod` and the devcontainer move together and the alignment check passes.

The pinned Go tool versions in the Dockerfile (`gopls@v0.21.1`, `dlv@v1.26.1`, `staticcheck@v0.7.0`, `gotext@v0.35.0`) are already compatible with Go 1.26, so no further changes are needed there.

# Changes

| File | Change |
| --- | --- |
| `go.mod` | `go 1.25.10` -> `go 1.26`; `chroma/v2 2.24.1` -> `2.25.0`; `dlclark/regexp2 v1.12.0` -> `dlclark/regexp2/v2 v2.1.0` (indirect) |
| `go.sum` | regenerated |
| `.devcontainer/Dockerfile` | base image `go:1.25-bookworm` -> `go:1.26-bookworm` |

# Testing

- `go build ./...` passes locally with Go 1.26.0.
- CI's `check-go-version-alignment` job should now pass (both sides report `1.26`).

# Related

- Supersedes #762 (dependabot's chroma-only PR which cannot self-heal the Dockerfile).
- Failed run on #762: https://github.com/microsoft/go-sqlcmd/actions/runs/26483853463/job/77986892519
