### PR TITLE
ci: pin Go toolchain to 1.26.4 and unify version source

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,10 +13,11 @@ jobs:
     name: lint-pr-changes
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.0'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          go-version-file: go.mod
+          check-latest: true
       - name: golangci-lint
         # Pinned to commit SHA for supply chain security (CWE-829)
         # Verify: gh api repos/golangci/golangci-lint-action/git/ref/tags/v9 --jq '.object.sha'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: '1.26.0'
+        go-version-file: go.mod
+        check-latest: true
     - name: Run tests against Linux SQL
       run: |
         go version

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,9 +30,10 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/microsoft/go-sqlcmd
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/billgraziano/dpapi v0.5.0


### PR DESCRIPTION
## Problem

`govulncheck` is failing on every PR (e.g. [#769 run](https://github.com/microsoft/go-sqlcmd/actions/runs/26858168084/job/79205686307)) with exit code 3:

- **GO-2026-5039** — `net/textproto` arbitrary input in errors (reached via `container.Controller.ContainerFiles` → `io.ReadAll`)
- **GO-2026-5037** — `crypto/x509` inefficient hostname parsing (reached via `sqlCmdFormatterType.AddError` → `x509.HostnameError.Error`)

Both are stdlib bugs fixed in **Go 1.26.4**. The runner is using 1.26.3.

## Root Cause

Two cooperating gaps:

1. `go.mod` declared `go 1.26` with no `toolchain` directive, so setup-go resolved "1.26" against its cached release manifest and happily returned **1.26.3** (already in cache) — even though **1.26.4** is published in [`actions/go-versions`](https://github.com/actions/go-versions/blob/main/versions-manifest.json).
2. Two other workflows pinned `go-version: '1.26.0'` literally, so they drift from `go.mod` and need manual edits for every Go bump.
3. Dependabot does not currently update `go`/`toolchain` directives ([dependabot-core#8454](https://github.com/dependabot/dependabot-core/issues/8454)) and stdlib CVEs aren't in `require()`, so dependabot can't fix this for us.

## Solution

| File | Change | Why |
|---|---|---|
| `go.mod` | Add `toolchain go1.26.4` | Declares the minimum acceptable patch in one canonical place. setup-go honors it. |
| `.github/workflows/security.yml` | Add `check-latest: true` to setup-go | Forces the runner to consult the signed `actions/go-versions` manifest for the newest matching patch instead of serving a stale cache entry. |
| `.github/workflows/security.yml` | `govulncheck@latest` → `govulncheck@v1.1.4` | Removes a `@latest` supply-chain edge. The vuln DB itself is fetched at runtime, so DB freshness is unchanged. |
| `.github/workflows/pr-validation.yml` | `go-version: '1.26.0'` → `go-version-file: go.mod` + `check-latest: true` | Single source of truth — `go.mod` is the only place the version lives. |
| `.github/workflows/golangci-lint.yml` | Same as pr-validation.yml | Same — also fixes the pre-existing checkout-before-setup-go ordering. |

After this lands, bumping the Go patch is a one-line edit to the `toolchain` line in `go.mod`. All three workflows pick it up automatically on the next run.

## Testing

- `go build ./...` locally with `go1.26.4` (auto-downloaded by the `toolchain` directive) — succeeds.
- `govulncheck` will be exercised by this PR's own security.yml run.

## Why not split the commits

go.mod and the workflows are one change with one motivating cause (govulncheck failure). Splitting would land the workflow changes first and still leave govulncheck red until the go.mod change merged separately.

## Related

- Unblocks #769 and every future PR until the runner cache happens to refresh.
- Future follow-up (not in this PR): if `toolchain` line bumps become frequent, add a scheduled workflow that opens a PR via `peter-evans/create-pull-request`. Skipping for now — manual edits are fine given Go's patch cadence.
