### PR TITLE
ci: add docker and devcontainers ecosystems to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,43 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Enable version updates for the release Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Enable version updates for the devcontainer Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "devcontainer"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Enable version updates for devcontainer features
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "devcontainer"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` tracks `gomod` and `github-actions` but not:

- The top-level `Dockerfile` (release image base)
- `.devcontainer/Dockerfile` (developer environment base)
- `.devcontainer/devcontainer.json` features

So base image and devcontainer feature updates are invisible to Dependabot.

## Changes

Adds three ecosystem blocks:

| Ecosystem | Directory | Cadence | Label |
|---|---|---|---|
| `docker` | `/` | weekly | `docker` |
| `docker` | `/.devcontainer` | weekly | `docker`, `devcontainer` |
| `devcontainers` | `/` | weekly | `devcontainer` |

Weekly (not daily) to avoid PR churn on slow-moving base images. All use the existing `deps:` / `ci:` commit prefixes so release-please continues to classify them correctly.

## Notes

- The `toolchain` directive in `go.mod` is still not covered (Dependabot product gap, [dependabot-core#8454](https://github.com/dependabot/dependabot-core/issues/8454)). That bump remains manual.
- Companion to #770, which pinned the Go toolchain to fix the recurring govulncheck failure.
