### PR TITLE
ci: support variant-prefixed devcontainer Go tags

### DIFF
--- a/.github/workflows/devcontainer-check.yml
+++ b/.github/workflows/devcontainer-check.yml
@@ -23,8 +23,10 @@ jobs:
           GOMOD_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
           GOMOD_MAJOR_MINOR=$(echo "$GOMOD_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
 
-          # Extract the Go version from the Dockerfile base image tag
-          DOCKERFILE_TAG=$(grep -oP 'devcontainers/go:\K[0-9]+\.[0-9]+' .devcontainer/Dockerfile)
+          # Extract the Go version from the Dockerfile base image tag.
+          # Accept both the legacy form (go:1.26-bookworm) and the variant-prefixed
+          # form (go:2-1.26-bookworm) published on mcr.microsoft.com.
+          DOCKERFILE_TAG=$(grep -oP 'devcontainers/go:(?:[0-9]+-)?\K[0-9]+\.[0-9]+' .devcontainer/Dockerfile)
 
           echo "go.mod requires:        go ${GOMOD_VERSION} (major.minor: ${GOMOD_MAJOR_MINOR})"
           echo "Dockerfile base image:  go:${DOCKERFILE_TAG}"


### PR DESCRIPTION
## Problem

The `devcontainer-version-check` workflow extracts the Go version from the base image tag in `.devcontainer/Dockerfile`:

```bash
DOCKERFILE_TAG=$(grep -oP 'devcontainers/go:\K[0-9]+\.[0-9]+' .devcontainer/Dockerfile)
```

The regex assumes the tag starts with `<major>.<minor>` (e.g. `1.26-bookworm`). Microsoft has begun publishing variant-prefixed tags such as `2-1.26-bookworm`, which the current regex does not match. When dependabot proposes that bump (#776), `DOCKERFILE_TAG` ends up empty and the job exits with:

```
ERROR: Could not parse versions
```

This blocks every dependabot PR that adopts the new tag form.

## Fix

Allow an optional leading `<digits>-` variant prefix in the regex:

```bash
DOCKERFILE_TAG=$(grep -oP 'devcontainers/go:(?:[0-9]+-)?\K[0-9]+\.[0-9]+' .devcontainer/Dockerfile)
```

Both forms now extract the same major.minor:

| Tag                  | Extracted |
|----------------------|-----------|
| `1.26-bookworm`      | `1.26`    |
| `2-1.26-bookworm`    | `1.26`    |
| `10-1.30-bookworm`   | `1.30`    |

No change to behavior for the legacy tag format. Once this merges, rebasing #776 should turn its `devcontainer-version-check` green.